### PR TITLE
feat: auto-register Discord channels by guild whitelist

### DIFF
--- a/src/channels/discord.test.ts
+++ b/src/channels/discord.test.ts
@@ -12,6 +12,7 @@ vi.mock('../env.js', () => ({ readEnvFile: vi.fn(() => ({})) }));
 vi.mock('../config.js', () => ({
   ASSISTANT_NAME: 'Andy',
   TRIGGER_PATTERN: /^@Andy\b/i,
+  DISCORD_AUTO_REGISTER_GUILDS: new Set(),
 }));
 
 // Mock logger

--- a/src/channels/discord.ts
+++ b/src/channels/discord.ts
@@ -1,6 +1,10 @@
 import { Client, Events, GatewayIntentBits, Message, TextChannel } from 'discord.js';
 
-import { ASSISTANT_NAME, TRIGGER_PATTERN } from '../config.js';
+import {
+  ASSISTANT_NAME,
+  DISCORD_AUTO_REGISTER_GUILDS,
+  TRIGGER_PATTERN,
+} from '../config.js';
 import { readEnvFile } from '../env.js';
 import { logger } from '../logger.js';
 import { registerChannel, ChannelOpts } from './registry.js';
@@ -15,6 +19,7 @@ export interface DiscordChannelOpts {
   onMessage: OnInboundMessage;
   onChatMetadata: OnChatMetadata;
   registeredGroups: () => Record<string, RegisteredGroup>;
+  autoRegisterGroup?: (jid: string, name: string, folderHint: string) => boolean;
 }
 
 export class DiscordChannel implements Channel {
@@ -128,13 +133,39 @@ export class DiscordChannel implements Channel {
       this.opts.onChatMetadata(chatJid, timestamp, chatName, 'discord', isGroup);
 
       // Only deliver full message for registered groups
-      const group = this.opts.registeredGroups()[chatJid];
+      let group = this.opts.registeredGroups()[chatJid];
       if (!group) {
-        logger.debug(
-          { chatJid, chatName },
-          'Message from unregistered Discord channel',
-        );
-        return;
+        // Auto-register if guild is whitelisted
+        if (
+          message.guild &&
+          DISCORD_AUTO_REGISTER_GUILDS.has(message.guild.id) &&
+          this.opts.autoRegisterGroup
+        ) {
+          const textCh = message.channel as TextChannel;
+          const sanitized = textCh.name.replace(/[^a-zA-Z0-9_-]/g, '');
+          const folderHint = sanitized
+            ? `dc_${sanitized.slice(0, 58)}`
+            : `dc_${channelId.slice(-12)}`;
+          const registered = this.opts.autoRegisterGroup(
+            chatJid,
+            chatName,
+            folderHint,
+          );
+          if (registered) {
+            group = this.opts.registeredGroups()[chatJid];
+            logger.info(
+              { chatJid, chatName, folder: folderHint },
+              'Auto-registered Discord channel',
+            );
+          }
+        }
+        if (!group) {
+          logger.debug(
+            { chatJid, chatName },
+            'Message from unregistered Discord channel',
+          );
+          return;
+        }
       }
 
       // Deliver message — startMessageLoop() will pick it up

--- a/src/channels/registry.ts
+++ b/src/channels/registry.ts
@@ -9,6 +9,7 @@ export interface ChannelOpts {
   onMessage: OnInboundMessage;
   onChatMetadata: OnChatMetadata;
   registeredGroups: () => Record<string, RegisteredGroup>;
+  autoRegisterGroup?: (jid: string, name: string, folderHint: string) => boolean;
 }
 
 export type ChannelFactory = (opts: ChannelOpts) => Channel | null;

--- a/src/config.ts
+++ b/src/config.ts
@@ -67,6 +67,20 @@ export const TRIGGER_PATTERN = new RegExp(
   'i',
 );
 
+// Discord guild IDs that auto-register channels on first message.
+// Comma-separated list of guild IDs, e.g., "123456789,987654321"
+const autoRegisterEnv = readEnvFile(['DISCORD_AUTO_REGISTER_GUILDS']);
+export const DISCORD_AUTO_REGISTER_GUILDS = new Set(
+  (
+    process.env.DISCORD_AUTO_REGISTER_GUILDS ||
+    autoRegisterEnv.DISCORD_AUTO_REGISTER_GUILDS ||
+    ''
+  )
+    .split(',')
+    .map((s) => s.trim())
+    .filter(Boolean),
+);
+
 // Timezone for scheduled tasks (cron expressions, etc.)
 // Uses system timezone by default
 export const TIMEZONE =

--- a/src/index.ts
+++ b/src/index.ts
@@ -490,6 +490,35 @@ async function main(): Promise<void> {
 
   // Channel callbacks (shared by all channels)
   const channelOpts = {
+    autoRegisterGroup: (
+      jid: string,
+      name: string,
+      folderHint: string,
+    ): boolean => {
+      // Deduplicate: check if folder is already taken
+      const existingFolders = new Set(
+        Object.values(registeredGroups).map((g) => g.folder),
+      );
+      let folder = folderHint;
+      if (existingFolders.has(folder)) {
+        const suffix = jid.replace(/^dc:/, '').slice(-6);
+        folder = `${folderHint.slice(0, 57)}_${suffix}`;
+      }
+
+      try {
+        registerGroup(jid, {
+          name,
+          folder,
+          trigger: `@${ASSISTANT_NAME}`,
+          added_at: new Date().toISOString(),
+          requiresTrigger: true,
+        });
+        return true;
+      } catch (err) {
+        logger.warn({ jid, folder, err }, 'Failed to auto-register group');
+        return false;
+      }
+    },
     onMessage: (chatJid: string, msg: NewMessage) => {
       // Sender allowlist drop mode: discard messages from denied senders before storing
       if (!msg.is_from_me && !msg.is_bot_message && registeredGroups[chatJid]) {


### PR DESCRIPTION
## Summary

- Add `DISCORD_AUTO_REGISTER_GUILDS` env var (comma-separated guild IDs)
- When a message arrives from an unregistered channel in a whitelisted guild, the channel is automatically registered with `requiresTrigger: true`
- Folder naming uses sanitized channel name (`dc_{name}`), falls back to channel ID suffix for non-ASCII channel names
- Add `autoRegisterGroup` optional callback to `ChannelOpts` (generic, available to all channels)

## Motivation

Currently each Discord channel must be manually registered as a group via IPC from the main channel. For users with a personal Discord server, this is tedious — every new channel requires explicit registration. This feature lets users whitelist their guild so all channels auto-register on first message.

## Changes

| File | Change |
|------|--------|
| `src/config.ts` | Add `DISCORD_AUTO_REGISTER_GUILDS` env var |
| `src/channels/registry.ts` | Add optional `autoRegisterGroup` to `ChannelOpts` |
| `src/channels/discord.ts` | Auto-register logic in `onMessage` handler |
| `src/channels/discord.test.ts` | Update config mock |
| `src/index.ts` | Implement `autoRegisterGroup` callback |

## Test plan

- [x] All existing tests pass
- [x] Build succeeds
- [x] Manual test: set `DISCORD_AUTO_REGISTER_GUILDS=<guild_id>` in `.env`, send message in new channel, verify auto-registration (group folder created, agent responds)
- [x] Verified non-ASCII channel names fall back to channel ID suffix
- [ ] Verify no auto-registration when env var is unset (default behavior unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)