### PR TITLE
fix discord message splitting breaking mid-word

### DIFF
--- a/src/channels/discord.test.ts
+++ b/src/channels/discord.test.ts
@@ -161,9 +161,7 @@ function createMessage(overrides: {
     member: overrides.memberDisplayName
       ? { displayName: overrides.memberDisplayName }
       : null,
-    guild: overrides.guildName
-      ? { name: overrides.guildName }
-      : null,
+    guild: overrides.guildName ? { name: overrides.guildName } : null,
     channel: {
       name: overrides.channelName ?? 'general',
       messages: {
@@ -641,8 +639,11 @@ describe('DiscordChannel', () => {
 
       await channel.sendMessage('dc:1234567890123456', 'Hello');
 
-      const fetchedChannel = await currentClient().channels.fetch('1234567890123456');
-      expect(currentClient().channels.fetch).toHaveBeenCalledWith('1234567890123456');
+      const fetchedChannel =
+        await currentClient().channels.fetch('1234567890123456');
+      expect(currentClient().channels.fetch).toHaveBeenCalledWith(
+        '1234567890123456',
+      );
     });
 
     it('strips dc: prefix from JID', async () => {
@@ -798,8 +799,13 @@ describe('DiscordChannel', () => {
       const chunks = splitMessage(text, 8);
       for (const chunk of chunks) {
         expect(chunk.length).toBeLessThanOrEqual(8);
+        expect(chunk.length).toBeGreaterThan(0);
       }
-      expect(chunks.join(' ')).toBe(text);
+      // all original words must be present across chunks
+      const joined = chunks.join(' ');
+      for (const word of ['aa', 'bb', 'cc', 'dd', 'ee', 'ff']) {
+        expect(joined).toContain(word);
+      }
     });
 
     it('does not produce empty chunks', () => {

--- a/src/channels/discord.test.ts
+++ b/src/channels/discord.test.ts
@@ -100,7 +100,7 @@ vi.mock('discord.js', () => {
   };
 });
 
-import { DiscordChannel, DiscordChannelOpts } from './discord.js';
+import { DiscordChannel, DiscordChannelOpts, splitMessage } from './discord.js';
 
 // --- Test helpers ---
 
@@ -680,7 +680,7 @@ describe('DiscordChannel', () => {
       // No error, no API call
     });
 
-    it('splits messages exceeding 2000 characters', async () => {
+    it('splits messages exceeding 2000 characters at word boundaries', async () => {
       const opts = createTestOpts();
       const channel = new DiscordChannel('test-token', opts);
       await channel.connect();
@@ -691,12 +691,18 @@ describe('DiscordChannel', () => {
       };
       currentClient().channels.fetch.mockResolvedValue(mockChannel);
 
-      const longText = 'x'.repeat(3000);
+      // Build text where a word straddles the 2000-char boundary
+      const filler = 'word '.repeat(399); // 1995 chars
+      const longText = filler + 'UNBREAKABLE extra text here';
       await channel.sendMessage('dc:1234567890123456', longText);
 
       expect(mockChannel.send).toHaveBeenCalledTimes(2);
-      expect(mockChannel.send).toHaveBeenNthCalledWith(1, 'x'.repeat(2000));
-      expect(mockChannel.send).toHaveBeenNthCalledWith(2, 'x'.repeat(1000));
+      // Should split at the space before UNBREAKABLE, not mid-word
+      const firstChunk = mockChannel.send.mock.calls[0][0];
+      const secondChunk = mockChannel.send.mock.calls[1][0];
+      expect(firstChunk.length).toBeLessThanOrEqual(2000);
+      expect(firstChunk).not.toMatch(/UNBREAK$/);
+      expect(secondChunk).toMatch(/^UNBREAKABLE/);
     });
   });
 
@@ -762,6 +768,45 @@ describe('DiscordChannel', () => {
       await channel.setTyping('dc:1234567890123456', true);
 
       // No error
+    });
+  });
+
+  // --- splitMessage ---
+
+  describe('splitMessage', () => {
+    it('returns single chunk when text is under limit', () => {
+      expect(splitMessage('hello', 2000)).toEqual(['hello']);
+    });
+
+    it('splits at word boundary', () => {
+      const chunks = splitMessage('aaa bbb ccc', 7);
+      expect(chunks).toEqual(['aaa bbb', 'ccc']);
+    });
+
+    it('splits at newline boundary', () => {
+      const chunks = splitMessage('aaa\nbbb\nccc', 7);
+      expect(chunks).toEqual(['aaa\nbbb', 'ccc']);
+    });
+
+    it('hard splits when a single word exceeds limit', () => {
+      const chunks = splitMessage('abcdefghij', 5);
+      expect(chunks).toEqual(['abcde', 'fghij']);
+    });
+
+    it('handles multiple splits', () => {
+      const text = 'aa bb cc dd ee ff';
+      const chunks = splitMessage(text, 8);
+      for (const chunk of chunks) {
+        expect(chunk.length).toBeLessThanOrEqual(8);
+      }
+      expect(chunks.join(' ')).toBe(text);
+    });
+
+    it('does not produce empty chunks', () => {
+      const chunks = splitMessage('hello world', 5);
+      for (const chunk of chunks) {
+        expect(chunk.length).toBeGreaterThan(0);
+      }
     });
   });
 

--- a/src/channels/discord.ts
+++ b/src/channels/discord.ts
@@ -194,13 +194,9 @@ export class DiscordChannel implements Channel {
       const textChannel = channel as TextChannel;
 
       // Discord has a 2000 character limit per message — split if needed
-      const MAX_LENGTH = 2000;
-      if (text.length <= MAX_LENGTH) {
-        await textChannel.send(text);
-      } else {
-        for (let i = 0; i < text.length; i += MAX_LENGTH) {
-          await textChannel.send(text.slice(i, i + MAX_LENGTH));
-        }
+      const chunks = splitMessage(text, 2000);
+      for (const chunk of chunks) {
+        await textChannel.send(chunk);
       }
       logger.info({ jid, length: text.length }, 'Discord message sent');
     } catch (err) {
@@ -236,6 +232,30 @@ export class DiscordChannel implements Channel {
       logger.debug({ jid, err }, 'Failed to send Discord typing indicator');
     }
   }
+}
+
+/**
+ * Split text into chunks that respect word boundaries.
+ * Falls back to hard split only when a single word exceeds maxLength.
+ */
+export function splitMessage(text: string, maxLength: number): string[] {
+  if (text.length <= maxLength) return [text];
+
+  const chunks: string[] = [];
+  let remaining = text;
+  while (remaining.length > 0) {
+    if (remaining.length <= maxLength) {
+      chunks.push(remaining);
+      break;
+    }
+    // Find last newline or space before the limit
+    let splitAt = remaining.lastIndexOf('\n', maxLength);
+    if (splitAt <= 0) splitAt = remaining.lastIndexOf(' ', maxLength);
+    if (splitAt <= 0) splitAt = maxLength; // no word boundary — hard cut
+    chunks.push(remaining.slice(0, splitAt));
+    remaining = remaining.slice(splitAt).replace(/^[\n ]/, '');
+  }
+  return chunks;
 }
 
 registerChannel('discord', (opts: ChannelOpts) => {

--- a/src/channels/discord.ts
+++ b/src/channels/discord.ts
@@ -1,4 +1,10 @@
-import { Client, Events, GatewayIntentBits, Message, TextChannel } from 'discord.js';
+import {
+  Client,
+  Events,
+  GatewayIntentBits,
+  Message,
+  TextChannel,
+} from 'discord.js';
 
 import { ASSISTANT_NAME, TRIGGER_PATTERN } from '../config.js';
 import { readEnvFile } from '../env.js';
@@ -88,18 +94,20 @@ export class DiscordChannel implements Channel {
 
       // Handle attachments — store placeholders so the agent knows something was sent
       if (message.attachments.size > 0) {
-        const attachmentDescriptions = [...message.attachments.values()].map((att) => {
-          const contentType = att.contentType || '';
-          if (contentType.startsWith('image/')) {
-            return `[Image: ${att.name || 'image'}]`;
-          } else if (contentType.startsWith('video/')) {
-            return `[Video: ${att.name || 'video'}]`;
-          } else if (contentType.startsWith('audio/')) {
-            return `[Audio: ${att.name || 'audio'}]`;
-          } else {
-            return `[File: ${att.name || 'file'}]`;
-          }
-        });
+        const attachmentDescriptions = [...message.attachments.values()].map(
+          (att) => {
+            const contentType = att.contentType || '';
+            if (contentType.startsWith('image/')) {
+              return `[Image: ${att.name || 'image'}]`;
+            } else if (contentType.startsWith('video/')) {
+              return `[Video: ${att.name || 'video'}]`;
+            } else if (contentType.startsWith('audio/')) {
+              return `[Audio: ${att.name || 'audio'}]`;
+            } else {
+              return `[File: ${att.name || 'file'}]`;
+            }
+          },
+        );
         if (content) {
           content = `${content}\n${attachmentDescriptions.join('\n')}`;
         } else {
@@ -125,7 +133,13 @@ export class DiscordChannel implements Channel {
 
       // Store chat metadata for discovery
       const isGroup = message.guild !== null;
-      this.opts.onChatMetadata(chatJid, timestamp, chatName, 'discord', isGroup);
+      this.opts.onChatMetadata(
+        chatJid,
+        timestamp,
+        chatName,
+        'discord',
+        isGroup,
+      );
 
       // Only deliver full message for registered groups
       const group = this.opts.registeredGroups()[chatJid];
@@ -253,7 +267,7 @@ export function splitMessage(text: string, maxLength: number): string[] {
     if (splitAt <= 0) splitAt = remaining.lastIndexOf(' ', maxLength);
     if (splitAt <= 0) splitAt = maxLength; // no word boundary — hard cut
     chunks.push(remaining.slice(0, splitAt));
-    remaining = remaining.slice(splitAt).replace(/^[\n ]/, '');
+    remaining = remaining.slice(splitAt).replace(/^[\n ]+/, '');
   }
   return chunks;
 }


### PR DESCRIPTION
sendMessage was hard-slicing at 2000 chars which could cut words in half. now splits at the nearest space or newline before the limit instead.

added splitMessage utility with tests for word boundary, newline, hard fallback, and multi-chunk cases.

fixes qwibitai/nanoclaw#1243