### PR TITLE
fix(discord): harden multi-bot config and attachment downloads

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,1 +1,7 @@
+# Single Discord bot (default)
 DISCORD_BOT_TOKEN=
+
+# Multi-bot Discord (overrides DISCORD_BOT_TOKEN when set)
+# Format: name:token:triggerName separated by semicolons
+# Each bot gets its own identity, JID prefix (dc-{name}:), and trigger pattern.
+# DISCORD_BOTS=engineer:xMTbot1token...:Engineer;ops:xMTbot2token...:Ops

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,8 @@
       "dependencies": {
         "@onecli-sh/sdk": "^0.2.0",
         "better-sqlite3": "11.10.0",
-        "cron-parser": "5.5.0"
+        "cron-parser": "5.5.0",
+        "discord.js": "^14.18.0"
       },
       "devDependencies": {
         "@eslint/js": "^9.35.0",
@@ -28,6 +29,146 @@
       },
       "engines": {
         "node": ">=20"
+      }
+    },
+    "node_modules/@discordjs/builders": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/@discordjs/builders/-/builders-1.14.1.tgz",
+      "integrity": "sha512-gSKkhXLqs96TCzk66VZuHHl8z2bQMJFGwrXC0f33ngK+FLNau4hU1PYny3DNJfNdSH+gVMzE85/d5FQ2BpcNwQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@discordjs/formatters": "^0.6.2",
+        "@discordjs/util": "^1.2.0",
+        "@sapphire/shapeshift": "^4.0.0",
+        "discord-api-types": "^0.38.40",
+        "fast-deep-equal": "^3.1.3",
+        "ts-mixer": "^6.0.4",
+        "tslib": "^2.6.3"
+      },
+      "engines": {
+        "node": ">=16.11.0"
+      },
+      "funding": {
+        "url": "https://github.com/discordjs/discord.js?sponsor"
+      }
+    },
+    "node_modules/@discordjs/collection": {
+      "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/@discordjs/collection/-/collection-1.5.3.tgz",
+      "integrity": "sha512-SVb428OMd3WO1paV3rm6tSjM4wC+Kecaa1EUGX7vc6/fddvw/6lg90z4QtCqm21zvVe92vMMDt9+DkIvjXImQQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=16.11.0"
+      }
+    },
+    "node_modules/@discordjs/formatters": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/@discordjs/formatters/-/formatters-0.6.2.tgz",
+      "integrity": "sha512-y4UPwWhH6vChKRkGdMB4odasUbHOUwy7KL+OVwF86PvT6QVOwElx+TiI1/6kcmcEe+g5YRXJFiXSXUdabqZOvQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "discord-api-types": "^0.38.33"
+      },
+      "engines": {
+        "node": ">=16.11.0"
+      },
+      "funding": {
+        "url": "https://github.com/discordjs/discord.js?sponsor"
+      }
+    },
+    "node_modules/@discordjs/rest": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/@discordjs/rest/-/rest-2.6.1.tgz",
+      "integrity": "sha512-wwQdgjeaoYFiaG+atbqx6aJDpqW7JHAo0HrQkBTbYzM3/PJ3GweQIpgElNcGZ26DCUOXMyawYd0YF7vtr+fZXg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@discordjs/collection": "^2.1.1",
+        "@discordjs/util": "^1.2.0",
+        "@sapphire/async-queue": "^1.5.3",
+        "@sapphire/snowflake": "^3.5.5",
+        "@vladfrangu/async_event_emitter": "^2.4.6",
+        "discord-api-types": "^0.38.40",
+        "magic-bytes.js": "^1.13.0",
+        "tslib": "^2.6.3",
+        "undici": "6.24.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/discordjs/discord.js?sponsor"
+      }
+    },
+    "node_modules/@discordjs/rest/node_modules/@discordjs/collection": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@discordjs/collection/-/collection-2.1.1.tgz",
+      "integrity": "sha512-LiSusze9Tc7qF03sLCujF5iZp7K+vRNEDBZ86FT9aQAv3vxMLihUvKvpsCWiQ2DJq1tVckopKm1rxomgNUc9hg==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/discordjs/discord.js?sponsor"
+      }
+    },
+    "node_modules/@discordjs/rest/node_modules/@sapphire/snowflake": {
+      "version": "3.5.5",
+      "resolved": "https://registry.npmjs.org/@sapphire/snowflake/-/snowflake-3.5.5.tgz",
+      "integrity": "sha512-xzvBr1Q1c4lCe7i6sRnrofxeO1QTP/LKQ6A6qy0iB4x5yfiSfARMEQEghojzTNALDTcv8En04qYNIco9/K9eZQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=v14.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@discordjs/util": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@discordjs/util/-/util-1.2.0.tgz",
+      "integrity": "sha512-3LKP7F2+atl9vJFhaBjn4nOaSWahZ/yWjOvA4e5pnXkt2qyXRCHLxoBQy81GFtLGCq7K9lPm9R517M1U+/90Qg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "discord-api-types": "^0.38.33"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/discordjs/discord.js?sponsor"
+      }
+    },
+    "node_modules/@discordjs/ws": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@discordjs/ws/-/ws-1.2.3.tgz",
+      "integrity": "sha512-wPlQDxEmlDg5IxhJPuxXr3Vy9AjYq5xCvFWGJyD7w7Np8ZGu+Mc+97LCoEc/+AYCo2IDpKioiH0/c/mj5ZR9Uw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@discordjs/collection": "^2.1.0",
+        "@discordjs/rest": "^2.5.1",
+        "@discordjs/util": "^1.1.0",
+        "@sapphire/async-queue": "^1.5.2",
+        "@types/ws": "^8.5.10",
+        "@vladfrangu/async_event_emitter": "^2.2.4",
+        "discord-api-types": "^0.38.1",
+        "tslib": "^2.6.2",
+        "ws": "^8.17.0"
+      },
+      "engines": {
+        "node": ">=16.11.0"
+      },
+      "funding": {
+        "url": "https://github.com/discordjs/discord.js?sponsor"
+      }
+    },
+    "node_modules/@discordjs/ws/node_modules/@discordjs/collection": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@discordjs/collection/-/collection-2.1.1.tgz",
+      "integrity": "sha512-LiSusze9Tc7qF03sLCujF5iZp7K+vRNEDBZ86FT9aQAv3vxMLihUvKvpsCWiQ2DJq1tVckopKm1rxomgNUc9hg==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/discordjs/discord.js?sponsor"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -1043,6 +1184,39 @@
         "win32"
       ]
     },
+    "node_modules/@sapphire/async-queue": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@sapphire/async-queue/-/async-queue-1.5.5.tgz",
+      "integrity": "sha512-cvGzxbba6sav2zZkH8GPf2oGk9yYoD5qrNWdu9fRehifgnFZJMV+nuy2nON2roRO4yQQ+v7MK/Pktl/HgfsUXg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=v14.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@sapphire/shapeshift": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@sapphire/shapeshift/-/shapeshift-4.0.0.tgz",
+      "integrity": "sha512-d9dUmWVA7MMiKobL3VpLF8P2aeanRTu6ypG2OIaEv/ZHH/SUQ2iHOVyi5wAPjQ+HmnMuL0whK9ez8I/raWbtIg==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "lodash": "^4.17.21"
+      },
+      "engines": {
+        "node": ">=v16"
+      }
+    },
+    "node_modules/@sapphire/snowflake": {
+      "version": "3.5.3",
+      "resolved": "https://registry.npmjs.org/@sapphire/snowflake/-/snowflake-3.5.3.tgz",
+      "integrity": "sha512-jjmJywLAFoWeBi1W7994zZyiNWPIiqRRNAmSERxyg93xRGzNYvGjlZ0gR6x0F4gPRi2+0O6S71kOZYyr3cxaIQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=v14.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
     "node_modules/@standard-schema/spec": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
@@ -1095,10 +1269,18 @@
       "version": "22.19.11",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.11.tgz",
       "integrity": "sha512-BH7YwL6rA93ReqeQS1c4bsPpcfOmJasG+Fkr6Y59q83f9M1WcBRHR2vM+P9eOisYRcN3ujQoiZY8uk5W+1WL8w==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@types/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
       }
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
@@ -1479,6 +1661,16 @@
         "url": "https://opencollective.com/vitest"
       }
     },
+    "node_modules/@vladfrangu/async_event_emitter": {
+      "version": "2.4.7",
+      "resolved": "https://registry.npmjs.org/@vladfrangu/async_event_emitter/-/async_event_emitter-2.4.7.tgz",
+      "integrity": "sha512-Xfe6rpCTxSxfbswi/W/Pz7zp1WWSNn4A0eW4mLkQUewCrXXtMj31lCg+iQyTkh/CkusZSq9eDflu7tjEDXUY6g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=v14.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
     "node_modules/acorn": {
       "version": "8.16.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
@@ -1787,6 +1979,42 @@
         "node": ">=8"
       }
     },
+    "node_modules/discord-api-types": {
+      "version": "0.38.49",
+      "resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.38.49.tgz",
+      "integrity": "sha512-XnqcWmnFZFAE8ZM8SHAw9DIV8D3Or00rMQ8iQLotrEA2PmXhl+ykaf6L6q4l474hrSUH1JaYcv+iOMRWp2p6Tg==",
+      "license": "MIT",
+      "workspaces": [
+        "scripts/actions/documentation"
+      ]
+    },
+    "node_modules/discord.js": {
+      "version": "14.26.4",
+      "resolved": "https://registry.npmjs.org/discord.js/-/discord.js-14.26.4.tgz",
+      "integrity": "sha512-4oBp8tc6Kf8IDBwAHhbsMaAqx1b5fob9SNasZT7V6yyyUydoO5i5fGuX7TmvRtR+q/WgKRnRViRoAWnG7fNyvA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@discordjs/builders": "^1.14.1",
+        "@discordjs/collection": "1.5.3",
+        "@discordjs/formatters": "^0.6.2",
+        "@discordjs/rest": "^2.6.1",
+        "@discordjs/util": "^1.2.0",
+        "@discordjs/ws": "^1.2.3",
+        "@sapphire/snowflake": "3.5.3",
+        "discord-api-types": "^0.38.40",
+        "fast-deep-equal": "3.1.3",
+        "lodash.snakecase": "4.1.1",
+        "magic-bytes.js": "^1.13.0",
+        "tslib": "^2.6.3",
+        "undici": "6.24.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/discordjs/discord.js?sponsor"
+      }
+    },
     "node_modules/end-of-stream": {
       "version": "1.4.5",
       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
@@ -2044,8 +2272,7 @@
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
-      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-      "dev": true
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
     },
     "node_modules/fast-json-stable-stringify": {
       "version": "2.1.0",
@@ -2380,11 +2607,23 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/lodash": {
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
+      "license": "MIT"
+    },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
       "dev": true
+    },
+    "node_modules/lodash.snakecase": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.snakecase/-/lodash.snakecase-4.1.1.tgz",
+      "integrity": "sha512-QZ1d4xoBHYUeuouhEq3lk3Uq7ldgyFXGBhg04+oRLnIz8o9T65Eh+8YdroUwn846zchkA9yDsDl5CVVaV2nqYw==",
+      "license": "MIT"
     },
     "node_modules/luxon": {
       "version": "3.7.2",
@@ -2394,6 +2633,12 @@
       "engines": {
         "node": ">=12"
       }
+    },
+    "node_modules/magic-bytes.js": {
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/magic-bytes.js/-/magic-bytes.js-1.13.0.tgz",
+      "integrity": "sha512-afO2mnxW7GDTXMm5/AoN1WuOcdoKhtgXjIvHmobqTD1grNplhGdv3PFOyjCVmrnOZBIT/gD/koDKpYG+0mvHcg==",
+      "license": "MIT"
     },
     "node_modules/magic-string": {
       "version": "0.30.21",
@@ -3054,6 +3299,18 @@
         "typescript": ">=4.8.4"
       }
     },
+    "node_modules/ts-mixer": {
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/ts-mixer/-/ts-mixer-6.0.4.tgz",
+      "integrity": "sha512-ufKpbmrugz5Aou4wcr5Wc1UUFWOLhq+Fm6qa6P0w0K5Qw2yhaUoiWszhCVuNQyNwrlGiscHOmqYoAox1PtvgjA==",
+      "license": "MIT"
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
     "node_modules/tsx": {
       "version": "4.21.0",
       "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.21.0.tgz",
@@ -3135,11 +3392,19 @@
         "typescript": ">=4.8.4 <6.0.0"
       }
     },
+    "node_modules/undici": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.24.1.tgz",
+      "integrity": "sha512-sC+b0tB1whOCzbtlx20fx3WgCXwkW627p4EA9uM+/tNNPkSS+eSEld6pAs9nDv7WbY1UUljBMYPtu9BCOrCWKA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.17"
+      }
+    },
     "node_modules/undici-types": {
       "version": "6.21.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/uri-js": {
@@ -3356,6 +3621,27 @@
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "license": "ISC"
+    },
+    "node_modules/ws": {
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
     },
     "node_modules/yocto-queue": {
       "version": "0.1.0",

--- a/src/channels/discord.test.ts
+++ b/src/channels/discord.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
+import { describe, it, expect, beforeEach, vi, afterEach, beforeAll, afterAll } from 'vitest';
 
 // --- Mocks ---
 
@@ -12,6 +12,10 @@ vi.mock('../env.js', () => ({ readEnvFile: vi.fn(() => ({})) }));
 vi.mock('../config.js', () => ({
   ASSISTANT_NAME: 'Andy',
   TRIGGER_PATTERN: /^@Andy\b/i,
+  buildTriggerPattern: (trigger: string) => {
+    const escaped = trigger.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    return new RegExp(`^${escaped}\\b`, 'i');
+  },
 }));
 
 // Mock logger
@@ -161,9 +165,7 @@ function createMessage(overrides: {
     member: overrides.memberDisplayName
       ? { displayName: overrides.memberDisplayName }
       : null,
-    guild: overrides.guildName
-      ? { name: overrides.guildName }
-      : null,
+    guild: overrides.guildName ? { name: overrides.guildName } : null,
     channel: {
       name: overrides.channelName ?? 'general',
       messages: {
@@ -641,8 +643,11 @@ describe('DiscordChannel', () => {
 
       await channel.sendMessage('dc:1234567890123456', 'Hello');
 
-      const fetchedChannel = await currentClient().channels.fetch('1234567890123456');
-      expect(currentClient().channels.fetch).toHaveBeenCalledWith('1234567890123456');
+      const fetchedChannel =
+        await currentClient().channels.fetch('1234567890123456');
+      expect(currentClient().channels.fetch).toHaveBeenCalledWith(
+        '1234567890123456',
+      );
     });
 
     it('strips dc: prefix from JID', async () => {
@@ -772,5 +777,78 @@ describe('DiscordChannel', () => {
       const channel = new DiscordChannel('test-token', createTestOpts());
       expect(channel.name).toBe('discord');
     });
+
+    it('uses custom jidPrefix and triggerName from options', () => {
+      const channel = new DiscordChannel('test-token', createTestOpts(), {
+        jidPrefix: 'dc-eng',
+        label: 'engineer',
+        triggerName: 'Engineer',
+      });
+      expect(channel.name).toBe('discord');
+      expect(channel.ownsJid('dc-eng:12345')).toBe(true);
+      expect(channel.ownsJid('dc:12345')).toBe(false);
+    });
+  });
+});
+
+// --- parseDiscordBots ---
+
+describe('parseDiscordBots', () => {
+  let parseDiscordBots: typeof import('./discord.js').parseDiscordBots;
+
+  beforeAll(async () => {
+    const mod = await import('./discord.js');
+    parseDiscordBots = mod.parseDiscordBots;
+  });
+
+  it('parses valid entries', () => {
+    const result = parseDiscordBots('eng:TOKEN1:Engineer;ops:TOKEN2:Ops');
+    expect(result).toEqual([
+      { name: 'eng', token: 'TOKEN1', triggerName: 'Engineer' },
+      { name: 'ops', token: 'TOKEN2', triggerName: 'Ops' },
+    ]);
+  });
+
+  it('returns empty array for empty string', () => {
+    expect(parseDiscordBots('')).toEqual([]);
+    expect(parseDiscordBots('  ')).toEqual([]);
+  });
+
+  it('skips entries with wrong number of parts', () => {
+    const result = parseDiscordBots('bad-entry;eng:TOKEN1:Engineer');
+    expect(result).toEqual([
+      { name: 'eng', token: 'TOKEN1', triggerName: 'Engineer' },
+    ]);
+  });
+
+  it('rejects entries with more than 3 colon-delimited parts', () => {
+    const result = parseDiscordBots('eng:TOK:EN:Engineer');
+    expect(result).toEqual([]);
+  });
+
+  it('skips entries with empty fields', () => {
+    expect(parseDiscordBots(':TOKEN:Eng')).toEqual([]);
+    expect(parseDiscordBots('eng::Eng')).toEqual([]);
+    expect(parseDiscordBots('eng:TOKEN:')).toEqual([]);
+  });
+
+  it('rejects names with invalid characters', () => {
+    expect(parseDiscordBots('bot.ops:TOKEN:Ops')).toEqual([]);
+    expect(parseDiscordBots('bot+dev:TOKEN:Dev')).toEqual([]);
+    expect(parseDiscordBots('bot ops:TOKEN:Ops')).toEqual([]);
+  });
+
+  it('accepts hyphenated names', () => {
+    const result = parseDiscordBots('my-bot:TOKEN:MyBot');
+    expect(result).toEqual([
+      { name: 'my-bot', token: 'TOKEN', triggerName: 'MyBot' },
+    ]);
+  });
+
+  it('handles trailing semicolons and whitespace', () => {
+    const result = parseDiscordBots(' eng : TOKEN1 : Engineer ; ; ');
+    expect(result).toEqual([
+      { name: 'eng', token: 'TOKEN1', triggerName: 'Engineer' },
+    ]);
   });
 });

--- a/src/channels/discord.test.ts
+++ b/src/channels/discord.test.ts
@@ -44,6 +44,11 @@ vi.mock('discord.js', () => {
     DirectMessages: 8,
   };
 
+  const Partials = {
+    Channel: 0,
+    Message: 1,
+  };
+
   class MockClient {
     eventHandlers = new Map<string, Handler[]>();
     user: any = { id: '999888777', tag: 'Andy#1234' };
@@ -96,6 +101,7 @@ vi.mock('discord.js', () => {
     Client: MockClient,
     Events,
     GatewayIntentBits,
+    Partials,
     TextChannel,
   };
 });
@@ -188,6 +194,39 @@ function currentClient() {
 async function triggerMessage(message: any) {
   const handlers = currentClient().eventHandlers.get('messageCreate') || [];
   for (const h of handlers) await h(message);
+}
+
+async function triggerRawDM(overrides: {
+  channelId?: string;
+  content?: string;
+  authorId?: string;
+  authorUsername?: string;
+  authorGlobalName?: string;
+  authorBot?: boolean;
+  messageId?: string;
+  timestamp?: string;
+  attachments?: any[];
+}) {
+  const packet = {
+    t: 'MESSAGE_CREATE',
+    d: {
+      channel_id: overrides.channelId ?? '1234567890123456',
+      id: overrides.messageId ?? 'msg_dm_001',
+      content: overrides.content ?? 'Hello from DM',
+      timestamp: overrides.timestamp ?? '2024-01-01T00:00:00.000Z',
+      author: {
+        id: overrides.authorId ?? '55512345',
+        username: overrides.authorUsername ?? 'alice',
+        global_name: overrides.authorGlobalName ?? 'Alice',
+        bot: overrides.authorBot,
+      },
+      guild_id: undefined,
+      channel_type: 1,
+      attachments: overrides.attachments ?? [],
+    },
+  };
+  const handlers = currentClient().eventHandlers.get('raw') || [];
+  for (const h of handlers) await h(packet);
 }
 
 // --- Tests ---
@@ -364,12 +403,10 @@ describe('DiscordChannel', () => {
       const channel = new DiscordChannel('test-token', opts);
       await channel.connect();
 
-      const msg = createMessage({
+      await triggerRawDM({
         content: 'Hello',
-        guildName: undefined,
-        authorDisplayName: 'Alice',
+        authorGlobalName: 'Alice',
       });
-      await triggerMessage(msg);
 
       expect(opts.onChatMetadata).toHaveBeenCalledWith(
         'dc:1234567890123456',

--- a/src/channels/discord.test.ts
+++ b/src/channels/discord.test.ts
@@ -86,6 +86,11 @@ vi.mock('discord.js', () => {
       fetch: vi.fn().mockResolvedValue({
         send: vi.fn().mockResolvedValue(undefined),
         sendTyping: vi.fn().mockResolvedValue(undefined),
+        messages: {
+          fetch: vi.fn().mockResolvedValue({
+            author: { username: 'Andy', displayName: 'Andy' },
+          }),
+        },
       }),
     };
 
@@ -206,6 +211,7 @@ async function triggerRawDM(overrides: {
   messageId?: string;
   timestamp?: string;
   attachments?: any[];
+  messageReference?: { message_id?: string };
 }) {
   const packet = {
     t: 'MESSAGE_CREATE',
@@ -223,6 +229,7 @@ async function triggerRawDM(overrides: {
       guild_id: undefined,
       channel_type: 1,
       attachments: overrides.attachments ?? [],
+      message_reference: overrides.messageReference,
     },
   };
   const handlers = currentClient().eventHandlers.get('raw') || [];
@@ -664,6 +671,174 @@ describe('DiscordChannel', () => {
         expect.objectContaining({
           content: '[Reply to Bob] I agree with that',
         }),
+      );
+    });
+  });
+
+  // --- Raw DM gateway handling ---
+  describe('raw DM gateway handling', () => {
+    it('delivers a DM exactly once when raw and high-level events both fire', async () => {
+      const opts = createTestOpts();
+      const channel = new DiscordChannel('test-token', opts);
+      await channel.connect();
+
+      await triggerRawDM({ content: 'same dm', messageId: 'dm_once' });
+      await triggerMessage(
+        createMessage({ content: 'same dm', messageId: 'dm_once' }),
+      );
+
+      expect(opts.onMessage).toHaveBeenCalledTimes(1);
+      expect(opts.onMessage).toHaveBeenCalledWith(
+        'dc:1234567890123456',
+        expect.objectContaining({ id: 'dm_once', content: 'same dm' }),
+      );
+    });
+
+    it('ignores bot-authored raw DMs', async () => {
+      const opts = createTestOpts();
+      const channel = new DiscordChannel('test-token', opts);
+      await channel.connect();
+
+      await triggerRawDM({ authorBot: true, content: 'bot dm' });
+
+      expect(opts.onChatMetadata).not.toHaveBeenCalled();
+      expect(opts.onMessage).not.toHaveBeenCalled();
+    });
+
+    it('delivers raw DM ids, sender, timestamp, JID, metadata, and text content', async () => {
+      const opts = createTestOpts();
+      const channel = new DiscordChannel('test-token', opts);
+      await channel.connect();
+
+      await triggerRawDM({
+        channelId: '1234567890123456',
+        content: 'plain dm',
+        authorId: 'user_123',
+        authorUsername: 'alice_user',
+        authorGlobalName: 'Alice Global',
+        messageId: 'dm_text_1',
+        timestamp: '2024-02-03T04:05:06.000Z',
+      });
+
+      expect(opts.onChatMetadata).toHaveBeenCalledWith(
+        'dc:1234567890123456',
+        '2024-02-03T04:05:06.000Z',
+        'Alice Global',
+        'discord',
+        false,
+      );
+      expect(opts.onMessage).toHaveBeenCalledWith('dc:1234567890123456', {
+        id: 'dm_text_1',
+        chat_jid: 'dc:1234567890123456',
+        sender: 'user_123',
+        sender_name: 'Alice Global',
+        content: 'plain dm',
+        timestamp: '2024-02-03T04:05:06.000Z',
+        is_from_me: false,
+      });
+    });
+
+    it('handles attachment-only raw DMs deterministically', async () => {
+      const opts = createTestOpts();
+      const channel = new DiscordChannel('test-token', opts);
+      await channel.connect();
+
+      await triggerRawDM({
+        content: '',
+        attachments: [
+          { filename: 'photo.png', content_type: 'image/png' },
+          { filename: 'clip.mp4', content_type: 'video/mp4' },
+          { filename: 'note.txt', content_type: 'text/plain' },
+        ],
+      });
+
+      expect(opts.onMessage).toHaveBeenCalledWith(
+        'dc:1234567890123456',
+        expect.objectContaining({
+          content: '[Image: photo.png]\n[Video: clip.mp4]\n[File: note.txt]',
+        }),
+      );
+    });
+
+    it('handles empty raw DMs deterministically', async () => {
+      const opts = createTestOpts();
+      const channel = new DiscordChannel('test-token', opts);
+      await channel.connect();
+
+      await triggerRawDM({ content: '', attachments: [] });
+
+      expect(opts.onMessage).toHaveBeenCalledWith(
+        'dc:1234567890123456',
+        expect.objectContaining({ content: '' }),
+      );
+    });
+
+    it('translates raw DM bot mentions like guild messages', async () => {
+      const opts = createTestOpts();
+      const channel = new DiscordChannel('test-token', opts);
+      await channel.connect();
+
+      await triggerRawDM({ content: '<@!999888777> check this' });
+
+      expect(opts.onMessage).toHaveBeenCalledWith(
+        'dc:1234567890123456',
+        expect.objectContaining({ content: '@Andy check this' }),
+      );
+    });
+
+    it('adds raw DM reply context like guild messages', async () => {
+      const opts = createTestOpts();
+      const channel = new DiscordChannel('test-token', opts);
+      await channel.connect();
+
+      await triggerRawDM({
+        content: 'yes',
+        messageReference: { message_id: 'bot_reply_1' },
+      });
+
+      expect(currentClient().channels.fetch).toHaveBeenCalledWith('1234567890123456');
+      expect(opts.onMessage).toHaveBeenCalledWith(
+        'dc:1234567890123456',
+        expect.objectContaining({ content: '[Reply to Andy] yes' }),
+      );
+    });
+
+    it('does not process unregistered raw DMs', async () => {
+      const opts = createTestOpts({ registeredGroups: vi.fn(() => ({})) });
+      const channel = new DiscordChannel('test-token', opts);
+      await channel.connect();
+
+      await triggerRawDM({ content: '@Andy hello' });
+
+      expect(opts.onChatMetadata).toHaveBeenCalledWith(
+        'dc:1234567890123456',
+        expect.any(String),
+        'Alice',
+        'discord',
+        false,
+      );
+      expect(opts.onMessage).not.toHaveBeenCalled();
+    });
+
+    it('ignores raw guild messages so guild message handling is unchanged', async () => {
+      const opts = createTestOpts();
+      const channel = new DiscordChannel('test-token', opts);
+      await channel.connect();
+
+      const rawHandlers = currentClient().eventHandlers.get('raw') || [];
+      for (const h of rawHandlers) {
+        await h({
+          t: 'MESSAGE_CREATE',
+          d: { guild_id: 'guild_1', channel_id: '1234567890123456' },
+        });
+      }
+
+      expect(opts.onMessage).not.toHaveBeenCalled();
+      await triggerMessage(createMessage({ content: 'guild ok', guildName: 'Server' }));
+      expect(opts.onMessage).toHaveBeenCalledTimes(1);
+      expect(opts.onMessage).toHaveBeenCalledWith(
+        'dc:1234567890123456',
+        expect.objectContaining({ content: 'guild ok' }),
       );
     });
   });

--- a/src/channels/discord.test.ts
+++ b/src/channels/discord.test.ts
@@ -85,7 +85,10 @@ vi.mock('discord.js', () => {
       return this.on(event, handler);
     }
 
-    async login(_token: string) {
+    async login(token: string) {
+      if (token === 'reject-token') {
+        throw new Error('Login rejected');
+      }
       this._ready = true;
       // Fire the ready event
       const readyHandlers = this.eventHandlers.get('ready') || [];
@@ -211,6 +214,32 @@ function currentClient() {
   return clientRef.current;
 }
 
+function streamFromChunks(chunks: Array<string | Uint8Array>): ReadableStream<Uint8Array> {
+  return new ReadableStream<Uint8Array>({
+    start(controller) {
+      for (const chunk of chunks) {
+        controller.enqueue(
+          typeof chunk === 'string' ? new TextEncoder().encode(chunk) : chunk,
+        );
+      }
+      controller.close();
+    },
+  });
+}
+
+function attachmentResponse(
+  body: Array<string | Uint8Array> = ['hello world'],
+  init: { status?: number; headers?: Record<string, string> } = {},
+) {
+  const status = init.status ?? 200;
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    headers: new Headers({ 'content-length': '11', ...init.headers }),
+    body: streamFromChunks(body),
+  };
+}
+
 async function triggerMessage(message: any) {
   const handlers = currentClient().eventHandlers.get('messageCreate') || [];
   for (const h of handlers) await h(message);
@@ -258,12 +287,7 @@ describe('DiscordChannel', () => {
     vi.clearAllMocks();
     vi.stubGlobal(
       'fetch',
-      vi.fn(async () => ({
-        ok: true,
-        status: 200,
-        headers: new Headers({ 'content-length': '11' }),
-        arrayBuffer: async () => Buffer.from('hello world'),
-      })),
+      vi.fn(async () => attachmentResponse()),
     );
     await fs.rm(testGroupsDir, { recursive: true, force: true });
   });
@@ -305,6 +329,18 @@ describe('DiscordChannel', () => {
 
       await channel.disconnect();
       expect(channel.isConnected()).toBe(false);
+    });
+
+    it('rejects connect() when Discord login rejects', async () => {
+      const opts = createTestOpts();
+      const channel = new DiscordChannel('reject-token', opts);
+
+      await expect(channel.connect()).rejects.toThrow('Login rejected');
+      expect(channel.isConnected()).toBe(false);
+      expect(logger.error).toHaveBeenCalledWith(
+        { err: 'Login rejected', bot: 'discord' },
+        'Discord bot login failed',
+      );
     });
 
     it('isConnected() returns false before connect', () => {
@@ -709,6 +745,188 @@ describe('DiscordChannel', () => {
           'utf8',
         ),
       ).resolves.toBe('hello world');
+    });
+
+    it('streams oversized attachment bodies and cleans partial files', async () => {
+      vi.spyOn(Date, 'now').mockReturnValue(1_700_000_000_010);
+      vi.stubGlobal(
+        'fetch',
+        vi.fn(async () =>
+          attachmentResponse(
+            [new Uint8Array(25 * 1024 * 1024), new Uint8Array(1)],
+            { headers: { 'content-length': '' } },
+          ),
+        ),
+      );
+      const opts = createTestOpts();
+      const channel = new DiscordChannel('test-token', opts);
+      await channel.connect();
+
+      await triggerMessage(
+        createMessage({
+          content: '',
+          guildName: 'Server',
+          attachments: new Map([
+            [
+              'big',
+              {
+                id: 'big',
+                name: 'big.bin',
+                contentType: 'application/octet-stream',
+                url: 'https://cdn.discordapp.com/big.bin',
+              },
+            ],
+          ]),
+        }),
+      );
+
+      expect(opts.onMessage).toHaveBeenCalledWith(
+        'dc:1234567890123456',
+        expect.objectContaining({ content: '[File: big.bin]' }),
+      );
+      const attachmentDir = path.join(testGroupsDir, 'test-server', 'attachments');
+      await expect(fs.readdir(attachmentDir)).resolves.toEqual([]);
+    });
+
+    it('rejects redirects to non-Discord hosts', async () => {
+      vi.stubGlobal(
+        'fetch',
+        vi.fn(async () =>
+          attachmentResponse([], {
+            status: 302,
+            headers: { location: 'https://example.com/file.txt' },
+          }),
+        ),
+      );
+      const opts = createTestOpts();
+      const channel = new DiscordChannel('test-token', opts);
+      await channel.connect();
+
+      await triggerMessage(
+        createMessage({
+          content: '',
+          guildName: 'Server',
+          attachments: new Map([
+            [
+              'redir',
+              {
+                id: 'redir',
+                name: 'file.txt',
+                contentType: 'text/plain',
+                url: 'https://cdn.discordapp.com/file.txt',
+              },
+            ],
+          ]),
+        }),
+      );
+
+      expect(opts.onMessage).toHaveBeenCalledWith(
+        'dc:1234567890123456',
+        expect.objectContaining({ content: '[File: file.txt]' }),
+      );
+      expect(global.fetch).toHaveBeenCalledTimes(1);
+    });
+
+    it('rejects non-Discord attachment URLs before fetching', async () => {
+      const opts = createTestOpts();
+      const channel = new DiscordChannel('test-token', opts);
+      await channel.connect();
+
+      await triggerMessage(
+        createMessage({
+          content: '',
+          guildName: 'Server',
+          attachments: new Map([
+            [
+              'bad',
+              {
+                id: 'bad',
+                name: 'file.txt',
+                contentType: 'text/plain',
+                url: 'http://cdn.discordapp.com/file.txt',
+              },
+            ],
+          ]),
+        }),
+      );
+
+      expect(global.fetch).not.toHaveBeenCalled();
+      expect(opts.onMessage).toHaveBeenCalledWith(
+        'dc:1234567890123456',
+        expect.objectContaining({ content: '[File: file.txt]' }),
+      );
+    });
+
+    it('does not follow symlinked attachment directories outside the group', async () => {
+      const groupDir = path.join(testGroupsDir, 'test-server');
+      const outsideDir = path.join(testGroupsDir, 'outside');
+      await fs.mkdir(groupDir, { recursive: true });
+      await fs.mkdir(outsideDir, { recursive: true });
+      await fs.symlink(outsideDir, path.join(groupDir, 'attachments'));
+      const opts = createTestOpts();
+      const channel = new DiscordChannel('test-token', opts);
+      await channel.connect();
+
+      await triggerMessage(
+        createMessage({
+          content: '',
+          guildName: 'Server',
+          attachments: new Map([
+            [
+              'att1',
+              {
+                id: 'att1',
+                name: '../unsafe.txt',
+                contentType: 'text/plain',
+                url: 'https://cdn.discordapp.com/file.txt',
+                size: 11,
+              },
+            ],
+          ]),
+        }),
+      );
+
+      expect(opts.onMessage).toHaveBeenCalledWith(
+        'dc:1234567890123456',
+        expect.objectContaining({ content: '[File: ../unsafe.txt]' }),
+      );
+      await expect(fs.readdir(outsideDir)).resolves.toEqual([]);
+    });
+
+    it('does not overwrite existing files on filename collision', async () => {
+      vi.spyOn(Date, 'now').mockReturnValue(1_700_000_000_020);
+      const savedRelative = 'attachments/1700000000020-same-file.txt';
+      const savedPath = path.join(testGroupsDir, 'test-server', savedRelative);
+      await fs.mkdir(path.dirname(savedPath), { recursive: true });
+      await fs.writeFile(savedPath, 'original');
+      const opts = createTestOpts();
+      const channel = new DiscordChannel('test-token', opts);
+      await channel.connect();
+
+      await triggerMessage(
+        createMessage({
+          content: '',
+          guildName: 'Server',
+          attachments: new Map([
+            [
+              'same',
+              {
+                id: 'same',
+                name: 'file.txt',
+                contentType: 'text/plain',
+                url: 'https://cdn.discordapp.com/file.txt',
+                size: 11,
+              },
+            ],
+          ]),
+        }),
+      );
+
+      expect(opts.onMessage).toHaveBeenCalledWith(
+        'dc:1234567890123456',
+        expect.objectContaining({ content: '[File: file.txt]' }),
+      );
+      await expect(fs.readFile(savedPath, 'utf8')).resolves.toBe('original');
     });
 
     it('does not download attachments for unregistered guild channels', async () => {

--- a/src/channels/discord.test.ts
+++ b/src/channels/discord.test.ts
@@ -7,6 +7,8 @@ import {
   afterEach,
   beforeAll,
 } from 'vitest';
+import fs from 'fs/promises';
+import path from 'path';
 
 // --- Mocks ---
 
@@ -20,6 +22,7 @@ vi.mock('../env.js', () => ({ readEnvFile: vi.fn(() => ({})) }));
 vi.mock('../config.js', () => ({
   ASSISTANT_NAME: 'Andy',
   TRIGGER_PATTERN: /^@Andy\b/i,
+  GROUPS_DIR: testGroupsDir,
   buildTriggerPattern: (trigger: string) => {
     const escaped = trigger.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
     return new RegExp(`^${escaped}\\b`, 'i');
@@ -41,6 +44,7 @@ vi.mock('../logger.js', () => ({
 type Handler = (...args: any[]) => any;
 
 const clientRef = vi.hoisted(() => ({ current: null as any }));
+const testGroupsDir = vi.hoisted(() => '/tmp/nanoclaw-discord-test-groups');
 
 vi.mock('discord.js', () => {
   const Events = {
@@ -249,12 +253,23 @@ async function triggerRawDM(overrides: {
 // --- Tests ---
 
 describe('DiscordChannel', () => {
-  beforeEach(() => {
+  beforeEach(async () => {
     vi.clearAllMocks();
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => ({
+        ok: true,
+        status: 200,
+        headers: new Headers({ 'content-length': '11' }),
+        arrayBuffer: async () => Buffer.from('hello world'),
+      })),
+    );
+    await fs.rm(testGroupsDir, { recursive: true, force: true });
   });
 
   afterEach(() => {
     vi.restoreAllMocks();
+    vi.unstubAllGlobals();
   });
 
   // --- Connection lifecycle ---
@@ -659,6 +674,64 @@ describe('DiscordChannel', () => {
         }),
       );
     });
+
+    it('downloads registered guild attachments into the group attachments folder', async () => {
+      vi.spyOn(Date, 'now').mockReturnValue(1_700_000_000_000);
+      const opts = createTestOpts();
+      const channel = new DiscordChannel('test-token', opts);
+      await channel.connect();
+
+      const attachments = new Map([
+        [
+          'att1',
+          {
+            id: 'att1',
+            name: '../unsafe report.pdf',
+            contentType: 'application/pdf',
+            url: 'https://cdn.discordapp.com/report.pdf',
+            size: 11,
+          },
+        ],
+      ]);
+      await triggerMessage(
+        createMessage({ content: '', attachments, guildName: 'Server' }),
+      );
+
+      const savedRelative = 'attachments/1700000000000-att1-unsafe_report.pdf';
+      expect(opts.onMessage).toHaveBeenCalledWith(
+        'dc:1234567890123456',
+        expect.objectContaining({ content: `[PDF: ${savedRelative}]` }),
+      );
+      await expect(
+        fs.readFile(
+          path.join(testGroupsDir, 'test-server', savedRelative),
+          'utf8',
+        ),
+      ).resolves.toBe('hello world');
+    });
+
+    it('does not download attachments for unregistered guild channels', async () => {
+      const opts = createTestOpts({ registeredGroups: vi.fn(() => ({})) });
+      const channel = new DiscordChannel('test-token', opts);
+      await channel.connect();
+
+      const attachments = new Map([
+        [
+          'att1',
+          {
+            name: 'photo.png',
+            contentType: 'image/png',
+            url: 'https://cdn.discordapp.com/photo.png',
+          },
+        ],
+      ]);
+      await triggerMessage(
+        createMessage({ content: '', attachments, guildName: 'Server' }),
+      );
+
+      expect(global.fetch).not.toHaveBeenCalled();
+      expect(opts.onMessage).not.toHaveBeenCalled();
+    });
   });
 
   // --- Reply context ---
@@ -768,6 +841,38 @@ describe('DiscordChannel', () => {
           content: '[Image: photo.png]\n[Video: clip.mp4]\n[File: note.txt]',
         }),
       );
+    });
+
+    it('downloads registered raw DM attachments through the shared attachment path', async () => {
+      vi.spyOn(Date, 'now').mockReturnValue(1_700_000_000_001);
+      const opts = createTestOpts();
+      const channel = new DiscordChannel('test-token', opts);
+      await channel.connect();
+
+      await triggerRawDM({
+        content: '',
+        attachments: [
+          {
+            id: 'dm1',
+            filename: 'photo.png',
+            content_type: 'image/png',
+            url: 'https://cdn.discordapp.com/photo.png',
+            size: 11,
+          },
+        ],
+      });
+
+      const savedRelative = 'attachments/1700000000001-dm1-photo.png';
+      expect(opts.onMessage).toHaveBeenCalledWith(
+        'dc:1234567890123456',
+        expect.objectContaining({ content: `[Image: ${savedRelative}]` }),
+      );
+      await expect(
+        fs.readFile(
+          path.join(testGroupsDir, 'test-server', savedRelative),
+          'utf8',
+        ),
+      ).resolves.toBe('hello world');
     });
 
     it('handles empty raw DMs deterministically', async () => {

--- a/src/channels/discord.test.ts
+++ b/src/channels/discord.test.ts
@@ -127,6 +127,7 @@ vi.mock('discord.js', () => {
   };
 });
 
+import { logger } from '../logger.js';
 import { DiscordChannel, DiscordChannelOpts } from './discord.js';
 
 // --- Test helpers ---
@@ -1177,5 +1178,15 @@ describe('parseDiscordBots', () => {
     expect(result).toEqual([
       { name: 'eng', token: 'TOKEN1', triggerName: 'Engineer' },
     ]);
+  });
+
+  it('does not log bot tokens when rejecting malformed entries', () => {
+    parseDiscordBots('eng:SECRET_TOKEN:Extra:Engineer;ops:OTHER_SECRET:');
+
+    const loggedPayloads = vi
+      .mocked(logger.warn)
+      .mock.calls.map((call) => JSON.stringify(call[0]));
+    expect(loggedPayloads.join('\n')).not.toContain('SECRET_TOKEN');
+    expect(loggedPayloads.join('\n')).not.toContain('OTHER_SECRET');
   });
 });

--- a/src/channels/discord.ts
+++ b/src/channels/discord.ts
@@ -1,6 +1,12 @@
-import { Client, Events, GatewayIntentBits, Message, TextChannel } from 'discord.js';
+import {
+  Client,
+  Events,
+  GatewayIntentBits,
+  Message,
+  TextChannel,
+} from 'discord.js';
 
-import { ASSISTANT_NAME, TRIGGER_PATTERN } from '../config.js';
+import { ASSISTANT_NAME, buildTriggerPattern } from '../config.js';
 import { readEnvFile } from '../env.js';
 import { logger } from '../logger.js';
 import { registerChannel, ChannelOpts } from './registry.js';
@@ -17,16 +23,36 @@ export interface DiscordChannelOpts {
   registeredGroups: () => Record<string, RegisteredGroup>;
 }
 
+export interface DiscordBotOptions {
+  jidPrefix?: string;
+  label?: string;
+  triggerName?: string;
+}
+
 export class DiscordChannel implements Channel {
+  // Always 'discord' — used for ChannelType text-style passthrough.
+  // Bot identity is tracked via `label` in structured logs, not here.
   name = 'discord';
 
   private client: Client | null = null;
   private opts: DiscordChannelOpts;
   private botToken: string;
+  private jidPrefix: string;
+  private label: string;
+  private triggerName: string;
+  private triggerPattern: RegExp;
 
-  constructor(botToken: string, opts: DiscordChannelOpts) {
+  constructor(
+    botToken: string,
+    opts: DiscordChannelOpts,
+    options?: DiscordBotOptions,
+  ) {
     this.botToken = botToken;
     this.opts = opts;
+    this.jidPrefix = options?.jidPrefix ?? 'dc';
+    this.label = options?.label ?? 'discord';
+    this.triggerName = options?.triggerName ?? ASSISTANT_NAME;
+    this.triggerPattern = buildTriggerPattern(`@${this.triggerName}`);
   }
 
   async connect(): Promise<void> {
@@ -44,7 +70,7 @@ export class DiscordChannel implements Channel {
       if (message.author.bot) return;
 
       const channelId = message.channelId;
-      const chatJid = `dc:${channelId}`;
+      const chatJid = `${this.jidPrefix}:${channelId}`;
       let content = message.content;
       const timestamp = message.createdAt.toISOString();
       const senderName =
@@ -63,10 +89,11 @@ export class DiscordChannel implements Channel {
         chatName = senderName;
       }
 
-      // Translate Discord @bot mentions into TRIGGER_PATTERN format.
+      // Translate Discord @bot mentions into trigger format.
       // Discord mentions look like <@botUserId> — these won't match
-      // TRIGGER_PATTERN (e.g., ^@Andy\b), so we prepend the trigger
-      // when the bot is @mentioned.
+      // the trigger pattern (e.g., ^@Andy\b), so we prepend the trigger
+      // when the bot is @mentioned. In multi-bot setups, each bot injects
+      // its own triggerName so the correct group receives the message.
       if (this.client?.user) {
         const botId = this.client.user.id;
         const isBotMentioned =
@@ -79,27 +106,29 @@ export class DiscordChannel implements Channel {
           content = content
             .replace(new RegExp(`<@!?${botId}>`, 'g'), '')
             .trim();
-          // Prepend trigger if not already present
-          if (!TRIGGER_PATTERN.test(content)) {
-            content = `@${ASSISTANT_NAME} ${content}`;
+          // Prepend this bot's trigger if not already present
+          if (!this.triggerPattern.test(content)) {
+            content = `@${this.triggerName} ${content}`;
           }
         }
       }
 
       // Handle attachments — store placeholders so the agent knows something was sent
       if (message.attachments.size > 0) {
-        const attachmentDescriptions = [...message.attachments.values()].map((att) => {
-          const contentType = att.contentType || '';
-          if (contentType.startsWith('image/')) {
-            return `[Image: ${att.name || 'image'}]`;
-          } else if (contentType.startsWith('video/')) {
-            return `[Video: ${att.name || 'video'}]`;
-          } else if (contentType.startsWith('audio/')) {
-            return `[Audio: ${att.name || 'audio'}]`;
-          } else {
-            return `[File: ${att.name || 'file'}]`;
-          }
-        });
+        const attachmentDescriptions = [...message.attachments.values()].map(
+          (att) => {
+            const contentType = att.contentType || '';
+            if (contentType.startsWith('image/')) {
+              return `[Image: ${att.name || 'image'}]`;
+            } else if (contentType.startsWith('video/')) {
+              return `[Video: ${att.name || 'video'}]`;
+            } else if (contentType.startsWith('audio/')) {
+              return `[Audio: ${att.name || 'audio'}]`;
+            } else {
+              return `[File: ${att.name || 'file'}]`;
+            }
+          },
+        );
         if (content) {
           content = `${content}\n${attachmentDescriptions.join('\n')}`;
         } else {
@@ -107,7 +136,9 @@ export class DiscordChannel implements Channel {
         }
       }
 
-      // Handle reply context — include who the user is replying to
+      // Handle reply context — include who the user is replying to.
+      // If the user is replying to the bot's own message, treat it as a trigger
+      // so the bot responds even in trigger-only channels.
       if (message.reference?.messageId) {
         try {
           const repliedTo = await message.channel.messages.fetch(
@@ -118,6 +149,13 @@ export class DiscordChannel implements Channel {
             repliedTo.author.displayName ||
             repliedTo.author.username;
           content = `[Reply to ${replyAuthor}] ${content}`;
+
+          // If replying to this bot, inject this bot's trigger
+          if (repliedTo.author.id === this.client?.user?.id) {
+            if (!this.triggerPattern.test(content)) {
+              content = `@${this.triggerName} ${content}`;
+            }
+          }
         } catch {
           // Referenced message may have been deleted
         }
@@ -125,13 +163,19 @@ export class DiscordChannel implements Channel {
 
       // Store chat metadata for discovery
       const isGroup = message.guild !== null;
-      this.opts.onChatMetadata(chatJid, timestamp, chatName, 'discord', isGroup);
+      this.opts.onChatMetadata(
+        chatJid,
+        timestamp,
+        chatName,
+        'discord',
+        isGroup,
+      );
 
       // Only deliver full message for registered groups
       const group = this.opts.registeredGroups()[chatJid];
       if (!group) {
         logger.debug(
-          { chatJid, chatName },
+          { chatJid, chatName, bot: this.label },
           'Message from unregistered Discord channel',
         );
         return;
@@ -149,25 +193,32 @@ export class DiscordChannel implements Channel {
       });
 
       logger.info(
-        { chatJid, chatName, sender: senderName },
+        { chatJid, chatName, sender: senderName, bot: this.label },
         'Discord message stored',
       );
     });
 
     // Handle errors gracefully
     this.client.on(Events.Error, (err) => {
-      logger.error({ err: err.message }, 'Discord client error');
+      logger.error(
+        { err: err.message, bot: this.label },
+        'Discord client error',
+      );
     });
 
     return new Promise<void>((resolve) => {
       this.client!.once(Events.ClientReady, (readyClient) => {
         logger.info(
-          { username: readyClient.user.tag, id: readyClient.user.id },
+          {
+            username: readyClient.user.tag,
+            id: readyClient.user.id,
+            bot: this.label,
+          },
           'Discord bot connected',
         );
-        console.log(`\n  Discord bot: ${readyClient.user.tag}`);
+        console.log(`\n  Discord bot [${this.label}]: ${readyClient.user.tag}`);
         console.log(
-          `  Use /chatid command or check channel IDs in Discord settings\n`,
+          `  JID prefix: ${this.jidPrefix}: — use /chatid or check Discord channel settings\n`,
         );
         resolve();
       });
@@ -178,16 +229,19 @@ export class DiscordChannel implements Channel {
 
   async sendMessage(jid: string, text: string): Promise<void> {
     if (!this.client) {
-      logger.warn('Discord client not initialized');
+      logger.warn({ bot: this.label }, 'Discord client not initialized');
       return;
     }
 
     try {
-      const channelId = jid.replace(/^dc:/, '');
+      const channelId = jid.replace(new RegExp(`^${this.jidPrefix}:`), '');
       const channel = await this.client.channels.fetch(channelId);
 
       if (!channel || !('send' in channel)) {
-        logger.warn({ jid }, 'Discord channel not found or not text-based');
+        logger.warn(
+          { jid, bot: this.label },
+          'Discord channel not found or not text-based',
+        );
         return;
       }
 
@@ -202,9 +256,15 @@ export class DiscordChannel implements Channel {
           await textChannel.send(text.slice(i, i + MAX_LENGTH));
         }
       }
-      logger.info({ jid, length: text.length }, 'Discord message sent');
+      logger.info(
+        { jid, length: text.length, bot: this.label },
+        'Discord message sent',
+      );
     } catch (err) {
-      logger.error({ jid, err }, 'Failed to send Discord message');
+      logger.error(
+        { jid, err, bot: this.label },
+        'Failed to send Discord message',
+      );
     }
   }
 
@@ -213,38 +273,131 @@ export class DiscordChannel implements Channel {
   }
 
   ownsJid(jid: string): boolean {
-    return jid.startsWith('dc:');
+    return jid.startsWith(`${this.jidPrefix}:`);
   }
 
   async disconnect(): Promise<void> {
     if (this.client) {
       this.client.destroy();
       this.client = null;
-      logger.info('Discord bot stopped');
+      logger.info({ bot: this.label }, 'Discord bot stopped');
     }
   }
 
   async setTyping(jid: string, isTyping: boolean): Promise<void> {
     if (!this.client || !isTyping) return;
     try {
-      const channelId = jid.replace(/^dc:/, '');
+      const channelId = jid.replace(new RegExp(`^${this.jidPrefix}:`), '');
       const channel = await this.client.channels.fetch(channelId);
       if (channel && 'sendTyping' in channel) {
         await (channel as TextChannel).sendTyping();
       }
     } catch (err) {
-      logger.debug({ jid, err }, 'Failed to send Discord typing indicator');
+      logger.debug(
+        { jid, err, bot: this.label },
+        'Failed to send Discord typing indicator',
+      );
     }
   }
 }
 
-registerChannel('discord', (opts: ChannelOpts) => {
+// ---------------------------------------------------------------------------
+// Multi-bot configuration
+// ---------------------------------------------------------------------------
+// Multiple Discord bots can be configured via the DISCORD_BOTS env var.
+// Each bot gets its own identity, JID prefix, and trigger name so the
+// router can distinguish which bot owns a given channel.
+//
+// Format:  DISCORD_BOTS=name:token:triggerName;name:token:triggerName
+// Example: DISCORD_BOTS=engineer:xMT...abc:Engineer;ops:xMT...xyz:Ops
+//
+// - name:        used for registry key (discord-{name}) and JID prefix (dc-{name}:)
+// - token:       Discord bot token (alphanumeric + . - _ only, no colons)
+// - triggerName: the trigger injected on @mention/reply (e.g. "Engineer" → @Engineer)
+//
+// Falls back to single DISCORD_BOT_TOKEN when DISCORD_BOTS is not set.
+// All instances keep name='discord' for text-style passthrough.
+
+interface DiscordBotConfig {
+  name: string;
+  token: string;
+  triggerName: string;
+}
+
+// Bot names must be alphanumeric + hyphens only (used in JID prefix and regex).
+const VALID_BOT_NAME = /^[a-z0-9-]+$/i;
+
+export function parseDiscordBots(raw?: string): DiscordBotConfig[] {
+  const envVars = readEnvFile(['DISCORD_BOTS']);
+  const value = raw ?? process.env.DISCORD_BOTS ?? envVars.DISCORD_BOTS ?? '';
+  if (!value.trim()) return [];
+
+  const bots: DiscordBotConfig[] = [];
+  for (const entry of value.split(';')) {
+    const trimmed = entry.trim();
+    if (!trimmed) continue;
+    // Format: name:token:triggerName — Discord tokens use alphanumeric + . - _
+    // and do not contain colons, so exactly 3 colon-delimited parts are expected.
+    const parts = trimmed.split(':');
+    if (parts.length !== 3) {
+      logger.warn(
+        { entry: trimmed },
+        'DISCORD_BOTS: skipping malformed entry (expected exactly name:token:triggerName)',
+      );
+      continue;
+    }
+    const name = parts[0].trim();
+    const token = parts[1].trim();
+    const triggerName = parts[2].trim();
+    if (!name || !token || !triggerName) {
+      logger.warn(
+        { entry: trimmed },
+        'DISCORD_BOTS: skipping entry with empty field',
+      );
+      continue;
+    }
+    if (!VALID_BOT_NAME.test(name)) {
+      logger.warn(
+        { name },
+        'DISCORD_BOTS: skipping entry — name must be alphanumeric + hyphens only',
+      );
+      continue;
+    }
+    bots.push({ name, token, triggerName });
+  }
+  return bots;
+}
+
+// Register bots
+const discordBots = parseDiscordBots();
+
+if (discordBots.length > 0) {
+  if (process.env.DISCORD_BOT_TOKEN || readEnvFile(['DISCORD_BOT_TOKEN']).DISCORD_BOT_TOKEN) {
+    logger.info(
+      'DISCORD_BOTS is set — ignoring DISCORD_BOT_TOKEN (multi-bot takes precedence)',
+    );
+  }
+  for (const bot of discordBots) {
+    const registryName = `discord-${bot.name}`;
+    const jidPrefix = `dc-${bot.name}`;
+    registerChannel(registryName, (opts: ChannelOpts) =>
+      new DiscordChannel(bot.token, opts, {
+        jidPrefix,
+        label: bot.name,
+        triggerName: bot.triggerName,
+      }),
+    );
+  }
+} else {
+  // Single-bot fallback: original behavior
   const envVars = readEnvFile(['DISCORD_BOT_TOKEN']);
   const token =
     process.env.DISCORD_BOT_TOKEN || envVars.DISCORD_BOT_TOKEN || '';
-  if (!token) {
-    logger.warn('Discord: DISCORD_BOT_TOKEN not set');
-    return null;
+  if (token) {
+    registerChannel('discord', (opts: ChannelOpts) =>
+      new DiscordChannel(token, opts),
+    );
+  } else {
+    logger.warn('Discord: no bot tokens set');
   }
-  return new DiscordChannel(token, opts);
-});
+}

--- a/src/channels/discord.ts
+++ b/src/channels/discord.ts
@@ -1,4 +1,11 @@
-import { Client, Events, GatewayIntentBits, Message, TextChannel } from 'discord.js';
+import {
+  Client,
+  Events,
+  GatewayIntentBits,
+  Message,
+  Partials,
+  TextChannel,
+} from 'discord.js';
 
 import { ASSISTANT_NAME, TRIGGER_PATTERN } from '../config.js';
 import { readEnvFile } from '../env.js';
@@ -37,11 +44,84 @@ export class DiscordChannel implements Channel {
         GatewayIntentBits.MessageContent,
         GatewayIntentBits.DirectMessages,
       ],
+      partials: [Partials.Channel, Partials.Message],
+    });
+
+    // Handle DMs via raw gateway events.
+    // discord.js v14 does not reliably emit messageCreate for DMs even with
+    // Partials.Channel enabled — the raw gateway event is the only reliable
+    // source. Guild messages still go through messageCreate below.
+    this.client.on('raw' as any, (packet: any) => {
+      if (packet.t !== 'MESSAGE_CREATE' || packet.d.guild_id) return;
+
+      const d = packet.d;
+      if (d.author?.bot) return;
+
+      const channelId = d.channel_id;
+      const chatJid = `dc:${channelId}`;
+      const senderName = d.author?.global_name || d.author?.username || 'Unknown';
+      const sender = d.author?.id || '';
+      const msgId = d.id;
+      const timestamp = d.timestamp || new Date().toISOString();
+      let content = d.content || '';
+
+      // Translate @bot mentions into trigger format
+      const botId = this.client?.user?.id;
+      if (botId) {
+        const isBotMentioned =
+          content.includes(`<@${botId}>`) ||
+          content.includes(`<@!${botId}>`);
+        if (isBotMentioned) {
+          content = content.replace(new RegExp(`<@!?${botId}>`, 'g'), '').trim();
+          if (!TRIGGER_PATTERN.test(content)) {
+            content = `@${ASSISTANT_NAME} ${content}`;
+          }
+        }
+      }
+
+      // Handle attachments
+      if (d.attachments?.length > 0) {
+        const descriptions = d.attachments.map((att: any) => {
+          const ct = att.content_type || '';
+          if (ct.startsWith('image/')) return `[Image: ${att.filename || 'image'}]`;
+          if (ct.startsWith('video/')) return `[Video: ${att.filename || 'video'}]`;
+          if (ct.startsWith('audio/')) return `[Audio: ${att.filename || 'audio'}]`;
+          return `[File: ${att.filename || 'file'}]`;
+        });
+        content = content
+          ? `${content}\n${descriptions.join('\n')}`
+          : descriptions.join('\n');
+      }
+
+      // Store chat metadata
+      this.opts.onChatMetadata(chatJid, timestamp, senderName, 'discord', false);
+
+      // Only deliver for registered groups
+      const group = this.opts.registeredGroups()[chatJid];
+      if (!group) {
+        logger.debug({ chatJid, chatName: senderName }, 'DM from unregistered Discord channel');
+        return;
+      }
+
+      this.opts.onMessage(chatJid, {
+        id: msgId,
+        chat_jid: chatJid,
+        sender,
+        sender_name: senderName,
+        content,
+        timestamp,
+        is_from_me: false,
+      });
+
+      logger.info({ chatJid, chatName: senderName, sender: senderName }, 'Discord DM stored');
     });
 
     this.client.on(Events.MessageCreate, async (message: Message) => {
       // Ignore bot messages (including own)
       if (message.author.bot) return;
+
+      // Skip DMs — handled by the raw event listener above
+      if (!message.guild) return;
 
       const channelId = message.channelId;
       const chatJid = `dc:${channelId}`;
@@ -55,13 +135,8 @@ export class DiscordChannel implements Channel {
       const msgId = message.id;
 
       // Determine chat name
-      let chatName: string;
-      if (message.guild) {
-        const textChannel = message.channel as TextChannel;
-        chatName = `${message.guild.name} #${textChannel.name}`;
-      } else {
-        chatName = senderName;
-      }
+      const textChannel = message.channel as TextChannel;
+      const chatName = `${message.guild.name} #${textChannel.name}`;
 
       // Translate Discord @bot mentions into TRIGGER_PATTERN format.
       // Discord mentions look like <@botUserId> — these won't match
@@ -88,18 +163,20 @@ export class DiscordChannel implements Channel {
 
       // Handle attachments — store placeholders so the agent knows something was sent
       if (message.attachments.size > 0) {
-        const attachmentDescriptions = [...message.attachments.values()].map((att) => {
-          const contentType = att.contentType || '';
-          if (contentType.startsWith('image/')) {
-            return `[Image: ${att.name || 'image'}]`;
-          } else if (contentType.startsWith('video/')) {
-            return `[Video: ${att.name || 'video'}]`;
-          } else if (contentType.startsWith('audio/')) {
-            return `[Audio: ${att.name || 'audio'}]`;
-          } else {
-            return `[File: ${att.name || 'file'}]`;
-          }
-        });
+        const attachmentDescriptions = [...message.attachments.values()].map(
+          (att) => {
+            const contentType = att.contentType || '';
+            if (contentType.startsWith('image/')) {
+              return `[Image: ${att.name || 'image'}]`;
+            } else if (contentType.startsWith('video/')) {
+              return `[Video: ${att.name || 'video'}]`;
+            } else if (contentType.startsWith('audio/')) {
+              return `[Audio: ${att.name || 'audio'}]`;
+            } else {
+              return `[File: ${att.name || 'file'}]`;
+            }
+          },
+        );
         if (content) {
           content = `${content}\n${attachmentDescriptions.join('\n')}`;
         } else {
@@ -124,8 +201,7 @@ export class DiscordChannel implements Channel {
       }
 
       // Store chat metadata for discovery
-      const isGroup = message.guild !== null;
-      this.opts.onChatMetadata(chatJid, timestamp, chatName, 'discord', isGroup);
+      this.opts.onChatMetadata(chatJid, timestamp, chatName, 'discord', true);
 
       // Only deliver full message for registered groups
       const group = this.opts.registeredGroups()[chatJid];

--- a/src/channels/discord.ts
+++ b/src/channels/discord.ts
@@ -23,6 +23,13 @@ import {
 
 const DISCORD_ATTACHMENT_TIMEOUT_MS = 15_000;
 const DISCORD_ATTACHMENT_MAX_BYTES = 25 * 1024 * 1024;
+const DISCORD_ATTACHMENT_MAX_TOTAL_BYTES = 50 * 1024 * 1024;
+const DISCORD_ATTACHMENT_MAX_REDIRECTS = 3;
+const DISCORD_ATTACHMENT_HOSTS = new Set([
+  'cdn.discordapp.com',
+  'media.discordapp.net',
+  'attachments.discordapp.net',
+]);
 let attachmentSaveCounter = 0;
 
 interface DiscordAttachmentLike {
@@ -70,6 +77,28 @@ function ensureWithinBase(baseDir: string, targetPath: string): void {
   }
 }
 
+async function ensureRealPathWithinBase(
+  baseDir: string,
+  targetPath: string,
+): Promise<void> {
+  const [realBase, realTarget] = await Promise.all([
+    fs.realpath(baseDir),
+    fs.realpath(targetPath),
+  ]);
+  ensureWithinBase(realBase, realTarget);
+}
+
+function validateDiscordAttachmentUrl(rawUrl: string): URL {
+  const url = new URL(rawUrl);
+  if (url.protocol !== 'https:') {
+    throw new Error('Discord attachment URL must use HTTPS');
+  }
+  if (!DISCORD_ATTACHMENT_HOSTS.has(url.hostname.toLowerCase())) {
+    throw new Error(`Discord attachment host is not allowed: ${url.hostname}`);
+  }
+  return url;
+}
+
 function safeAttachmentFilename(att: DiscordAttachmentLike): string {
   const base = path
     .basename(attachmentName(att))
@@ -88,14 +117,38 @@ function safeAttachmentFilename(att: DiscordAttachmentLike): string {
   return `${prefix}-${safeBase}`;
 }
 
-async function downloadDiscordAttachment(
-  att: DiscordAttachmentLike,
-): Promise<Buffer> {
-  if (!att.url) throw new Error('Discord attachment is missing a URL');
-  if (att.size && att.size > DISCORD_ATTACHMENT_MAX_BYTES) {
-    throw new Error(
-      `Discord attachment exceeds ${DISCORD_ATTACHMENT_MAX_BYTES} bytes`,
+async function fetchDiscordAttachment(
+  url: URL,
+  signal: AbortSignal,
+  redirectsRemaining = DISCORD_ATTACHMENT_MAX_REDIRECTS,
+): Promise<Response> {
+  const response = await fetch(url, { redirect: 'manual', signal });
+  if ([301, 302, 303, 307, 308].includes(response.status)) {
+    if (redirectsRemaining <= 0) {
+      throw new Error('Discord attachment redirect limit exceeded');
+    }
+    const location = response.headers.get('location');
+    if (!location) {
+      throw new Error('Discord attachment redirect missing Location');
+    }
+    const nextUrl = validateDiscordAttachmentUrl(
+      new URL(location, url).toString(),
     );
+    return fetchDiscordAttachment(nextUrl, signal, redirectsRemaining - 1);
+  }
+  return response;
+}
+
+async function downloadDiscordAttachmentToFile(
+  att: DiscordAttachmentLike,
+  destPath: string,
+  remainingBytes: number,
+): Promise<number> {
+  if (!att.url) throw new Error('Discord attachment is missing a URL');
+  const url = validateDiscordAttachmentUrl(att.url);
+  const maxBytes = Math.min(DISCORD_ATTACHMENT_MAX_BYTES, remainingBytes);
+  if (maxBytes <= 0 || (att.size && att.size > maxBytes)) {
+    throw new Error(`Discord attachment exceeds ${maxBytes} remaining bytes`);
   }
 
   const controller = new AbortController();
@@ -103,8 +156,13 @@ async function downloadDiscordAttachment(
     () => controller.abort(),
     DISCORD_ATTACHMENT_TIMEOUT_MS,
   );
+  const partialPath = `${destPath}.part-${process.pid}-${Date.now()}-${Math.random()
+    .toString(36)
+    .slice(2)}`;
+  let handle: Awaited<ReturnType<typeof fs.open>> | undefined;
+  let written = 0;
   try {
-    const response = await fetch(att.url, { signal: controller.signal });
+    const response = await fetchDiscordAttachment(url, controller.signal);
     if (!response.ok) {
       throw new Error(
         `Discord attachment download failed: HTTP ${response.status}`,
@@ -112,51 +170,74 @@ async function downloadDiscordAttachment(
     }
 
     const contentLength = response.headers.get('content-length');
-    if (contentLength && Number(contentLength) > DISCORD_ATTACHMENT_MAX_BYTES) {
-      throw new Error(
-        `Discord attachment exceeds ${DISCORD_ATTACHMENT_MAX_BYTES} bytes`,
-      );
+    if (contentLength && Number(contentLength) > maxBytes) {
+      throw new Error(`Discord attachment exceeds ${maxBytes} remaining bytes`);
+    }
+    if (!response.body) {
+      throw new Error('Discord attachment response has no body');
     }
 
-    const buffer = Buffer.from(await response.arrayBuffer());
-    if (buffer.byteLength > DISCORD_ATTACHMENT_MAX_BYTES) {
-      throw new Error(
-        `Discord attachment exceeds ${DISCORD_ATTACHMENT_MAX_BYTES} bytes`,
-      );
+    handle = await fs.open(partialPath, 'wx');
+    const reader = response.body.getReader();
+    for (;;) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      written += value.byteLength;
+      if (written > maxBytes) {
+        controller.abort();
+        throw new Error(`Discord attachment exceeds ${maxBytes} remaining bytes`);
+      }
+      await handle.writeFile(value);
     }
-    return buffer;
+    await handle.close();
+    handle = undefined;
+    await fs.link(partialPath, destPath);
+    await fs.rm(partialPath, { force: true });
+    return written;
   } finally {
     clearTimeout(timeout);
+    await handle?.close().catch(() => undefined);
+    await fs.rm(partialPath, { force: true }).catch(() => undefined);
   }
 }
 
 async function saveDiscordAttachment(
   att: DiscordAttachmentLike,
   group: RegisteredGroup | undefined,
-): Promise<string> {
-  if (!group || !att.url) return attachmentPlaceholder(att);
+  remainingBytes: number,
+): Promise<{ description: string; bytesSaved: number }> {
+  if (!group || !att.url) {
+    return { description: attachmentPlaceholder(att), bytesSaved: 0 };
+  }
 
   try {
     const groupDir = path.resolve(GROUPS_DIR, group.folder);
     ensureWithinBase(path.resolve(GROUPS_DIR), groupDir);
     const attachDir = path.resolve(groupDir, 'attachments');
     ensureWithinBase(groupDir, attachDir);
-
-    const buffer = await downloadDiscordAttachment(att);
     await fs.mkdir(attachDir, { recursive: true });
+    await ensureRealPathWithinBase(path.resolve(GROUPS_DIR), groupDir);
+    await ensureRealPathWithinBase(groupDir, attachDir);
 
     const filename = safeAttachmentFilename(att);
     const filePath = path.resolve(attachDir, filename);
     ensureWithinBase(attachDir, filePath);
-    await fs.writeFile(filePath, buffer, { flag: 'wx' });
+    const bytesSaved = await downloadDiscordAttachmentToFile(
+      att,
+      filePath,
+      remainingBytes,
+    );
 
-    return `[${attachmentKind(attachmentContentType(att))}: attachments/${filename}]`;
+    return {
+      description: `[${attachmentKind(attachmentContentType(att))}: attachments/${filename}]`,
+      bytesSaved,
+    };
   } catch (err) {
     logger.warn(
       { attName: attachmentName(att), err },
       'Failed to download Discord attachment',
     );
-    return attachmentPlaceholder(att);
+    return { description: attachmentPlaceholder(att), bytesSaved: 0 };
   }
 }
 
@@ -165,8 +246,11 @@ async function describeDiscordAttachments(
   group: RegisteredGroup | undefined,
 ): Promise<string[]> {
   const descriptions: string[] = [];
+  let remainingBytes = DISCORD_ATTACHMENT_MAX_TOTAL_BYTES;
   for (const att of attachments) {
-    descriptions.push(await saveDiscordAttachment(att, group));
+    const saved = await saveDiscordAttachment(att, group, remainingBytes);
+    remainingBytes -= saved.bytesSaved;
+    descriptions.push(saved.description);
   }
   return descriptions;
 }
@@ -445,8 +529,11 @@ export class DiscordChannel implements Channel {
       );
     });
 
-    return new Promise<void>((resolve) => {
+    return new Promise<void>((resolve, reject) => {
+      let settled = false;
+
       this.client!.once(Events.ClientReady, (readyClient) => {
+        settled = true;
         logger.info(
           {
             username: readyClient.user.tag,
@@ -462,7 +549,18 @@ export class DiscordChannel implements Channel {
         resolve();
       });
 
-      this.client!.login(this.botToken);
+      this.client!.login(this.botToken).catch((err: unknown) => {
+        if (settled) return;
+        settled = true;
+        const error = err instanceof Error ? err : new Error(String(err));
+        logger.error(
+          { err: error.message, bot: this.label },
+          'Discord bot login failed',
+        );
+        this.client?.destroy();
+        this.client = null;
+        reject(error);
+      });
     });
   }
 
@@ -572,6 +670,7 @@ export function parseDiscordBots(raw?: string): DiscordBotConfig[] {
   if (!value.trim()) return [];
 
   const bots: DiscordBotConfig[] = [];
+  const seenNames = new Set<string>();
   const entries = value.split(';');
   for (let index = 0; index < entries.length; index += 1) {
     const trimmed = entries[index].trim();
@@ -608,7 +707,16 @@ export function parseDiscordBots(raw?: string): DiscordBotConfig[] {
       );
       continue;
     }
-    bots.push({ name, token, triggerName });
+    const normalizedName = name.toLowerCase();
+    if (seenNames.has(normalizedName)) {
+      logger.warn(
+        { entryIndex: index, name: normalizedName },
+        'DISCORD_BOTS: skipping duplicate bot name',
+      );
+      continue;
+    }
+    seenNames.add(normalizedName);
+    bots.push({ name: normalizedName, token, triggerName });
   }
   return bots;
 }

--- a/src/channels/discord.ts
+++ b/src/channels/discord.ts
@@ -572,15 +572,16 @@ export function parseDiscordBots(raw?: string): DiscordBotConfig[] {
   if (!value.trim()) return [];
 
   const bots: DiscordBotConfig[] = [];
-  for (const entry of value.split(';')) {
-    const trimmed = entry.trim();
+  const entries = value.split(';');
+  for (let index = 0; index < entries.length; index += 1) {
+    const trimmed = entries[index].trim();
     if (!trimmed) continue;
     // Format: name:token:triggerName — Discord tokens use alphanumeric + . - _
     // and do not contain colons, so exactly 3 colon-delimited parts are expected.
     const parts = trimmed.split(':');
     if (parts.length !== 3) {
       logger.warn(
-        { entry: trimmed },
+        { entryIndex: index, fieldCount: parts.length },
         'DISCORD_BOTS: skipping malformed entry (expected exactly name:token:triggerName)',
       );
       continue;
@@ -590,7 +591,12 @@ export function parseDiscordBots(raw?: string): DiscordBotConfig[] {
     const triggerName = parts[2].trim();
     if (!name || !token || !triggerName) {
       logger.warn(
-        { entry: trimmed },
+        {
+          entryIndex: index,
+          name: name || undefined,
+          hasToken: Boolean(token),
+          hasTriggerName: Boolean(triggerName),
+        },
         'DISCORD_BOTS: skipping entry with empty field',
       );
       continue;

--- a/src/channels/discord.ts
+++ b/src/channels/discord.ts
@@ -51,7 +51,7 @@ export class DiscordChannel implements Channel {
     // discord.js v14 does not reliably emit messageCreate for DMs even with
     // Partials.Channel enabled — the raw gateway event is the only reliable
     // source. Guild messages still go through messageCreate below.
-    this.client.on('raw' as any, (packet: any) => {
+    this.client.on('raw' as any, async (packet: any) => {
       if (packet.t !== 'MESSAGE_CREATE' || packet.d.guild_id) return;
 
       const d = packet.d;
@@ -91,6 +91,29 @@ export class DiscordChannel implements Channel {
         content = content
           ? `${content}\n${descriptions.join('\n')}`
           : descriptions.join('\n');
+      }
+
+      // Handle reply context — keep DM formatting aligned with guild messages.
+      if (d.message_reference?.message_id) {
+        try {
+          const channel = await this.client?.channels.fetch(channelId);
+          if (channel && 'messages' in channel) {
+            const repliedTo = await (channel as any).messages.fetch(
+              d.message_reference.message_id,
+            );
+            const replyAuthor =
+              repliedTo.member?.displayName ||
+              repliedTo.author?.displayName ||
+              repliedTo.author?.globalName ||
+              repliedTo.author?.global_name ||
+              repliedTo.author?.username;
+            if (replyAuthor) {
+              content = `[Reply to ${replyAuthor}] ${content}`;
+            }
+          }
+        } catch {
+          // Referenced message may be unavailable.
+        }
       }
 
       // Store chat metadata

--- a/src/channels/discord.ts
+++ b/src/channels/discord.ts
@@ -1,3 +1,6 @@
+import fs from 'fs/promises';
+import path from 'path';
+
 import {
   Client,
   Events,
@@ -7,7 +10,7 @@ import {
   TextChannel,
 } from 'discord.js';
 
-import { ASSISTANT_NAME, buildTriggerPattern } from '../config.js';
+import { ASSISTANT_NAME, buildTriggerPattern, GROUPS_DIR } from '../config.js';
 import { readEnvFile } from '../env.js';
 import { logger } from '../logger.js';
 import { registerChannel, ChannelOpts } from './registry.js';
@@ -17,6 +20,156 @@ import {
   OnInboundMessage,
   RegisteredGroup,
 } from '../types.js';
+
+const DISCORD_ATTACHMENT_TIMEOUT_MS = 15_000;
+const DISCORD_ATTACHMENT_MAX_BYTES = 25 * 1024 * 1024;
+let attachmentSaveCounter = 0;
+
+interface DiscordAttachmentLike {
+  id?: string;
+  name?: string | null;
+  filename?: string | null;
+  contentType?: string | null;
+  content_type?: string | null;
+  url?: string | null;
+  size?: number | null;
+}
+
+function attachmentContentType(att: DiscordAttachmentLike): string {
+  return att.contentType || att.content_type || '';
+}
+
+function attachmentName(att: DiscordAttachmentLike): string {
+  return att.name || att.filename || 'file';
+}
+
+function attachmentKind(contentType: string): string {
+  if (contentType.startsWith('image/')) return 'Image';
+  if (contentType.startsWith('video/')) return 'Video';
+  if (contentType.startsWith('audio/')) return 'Audio';
+  if (contentType === 'application/pdf') return 'PDF';
+  return 'File';
+}
+
+function attachmentPlaceholderKind(contentType: string): string {
+  if (contentType.startsWith('image/')) return 'Image';
+  if (contentType.startsWith('video/')) return 'Video';
+  if (contentType.startsWith('audio/')) return 'Audio';
+  return 'File';
+}
+
+function attachmentPlaceholder(att: DiscordAttachmentLike): string {
+  const contentType = attachmentContentType(att);
+  return `[${attachmentPlaceholderKind(contentType)}: ${attachmentName(att)}]`;
+}
+
+function ensureWithinBase(baseDir: string, targetPath: string): void {
+  const relative = path.relative(baseDir, targetPath);
+  if (relative.startsWith('..') || path.isAbsolute(relative)) {
+    throw new Error(`Path escapes base directory: ${targetPath}`);
+  }
+}
+
+function safeAttachmentFilename(att: DiscordAttachmentLike): string {
+  const base = path
+    .basename(attachmentName(att))
+    .replace(/[^a-zA-Z0-9._-]/g, '_');
+  const safeBase =
+    base && base !== '.' && base !== '..' ? base.slice(0, 120) : 'file';
+  const prefix = [
+    Date.now(),
+    att.id ?? (attachmentSaveCounter = (attachmentSaveCounter + 1) % 1_000_000),
+  ]
+    .filter(
+      (part) => part !== undefined && part !== null && String(part).length > 0,
+    )
+    .map((part) => String(part).replace(/[^a-zA-Z0-9._-]/g, '_'))
+    .join('-');
+  return `${prefix}-${safeBase}`;
+}
+
+async function downloadDiscordAttachment(
+  att: DiscordAttachmentLike,
+): Promise<Buffer> {
+  if (!att.url) throw new Error('Discord attachment is missing a URL');
+  if (att.size && att.size > DISCORD_ATTACHMENT_MAX_BYTES) {
+    throw new Error(
+      `Discord attachment exceeds ${DISCORD_ATTACHMENT_MAX_BYTES} bytes`,
+    );
+  }
+
+  const controller = new AbortController();
+  const timeout = setTimeout(
+    () => controller.abort(),
+    DISCORD_ATTACHMENT_TIMEOUT_MS,
+  );
+  try {
+    const response = await fetch(att.url, { signal: controller.signal });
+    if (!response.ok) {
+      throw new Error(
+        `Discord attachment download failed: HTTP ${response.status}`,
+      );
+    }
+
+    const contentLength = response.headers.get('content-length');
+    if (contentLength && Number(contentLength) > DISCORD_ATTACHMENT_MAX_BYTES) {
+      throw new Error(
+        `Discord attachment exceeds ${DISCORD_ATTACHMENT_MAX_BYTES} bytes`,
+      );
+    }
+
+    const buffer = Buffer.from(await response.arrayBuffer());
+    if (buffer.byteLength > DISCORD_ATTACHMENT_MAX_BYTES) {
+      throw new Error(
+        `Discord attachment exceeds ${DISCORD_ATTACHMENT_MAX_BYTES} bytes`,
+      );
+    }
+    return buffer;
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+async function saveDiscordAttachment(
+  att: DiscordAttachmentLike,
+  group: RegisteredGroup | undefined,
+): Promise<string> {
+  if (!group || !att.url) return attachmentPlaceholder(att);
+
+  try {
+    const groupDir = path.resolve(GROUPS_DIR, group.folder);
+    ensureWithinBase(path.resolve(GROUPS_DIR), groupDir);
+    const attachDir = path.resolve(groupDir, 'attachments');
+    ensureWithinBase(groupDir, attachDir);
+
+    const buffer = await downloadDiscordAttachment(att);
+    await fs.mkdir(attachDir, { recursive: true });
+
+    const filename = safeAttachmentFilename(att);
+    const filePath = path.resolve(attachDir, filename);
+    ensureWithinBase(attachDir, filePath);
+    await fs.writeFile(filePath, buffer, { flag: 'wx' });
+
+    return `[${attachmentKind(attachmentContentType(att))}: attachments/${filename}]`;
+  } catch (err) {
+    logger.warn(
+      { attName: attachmentName(att), err },
+      'Failed to download Discord attachment',
+    );
+    return attachmentPlaceholder(att);
+  }
+}
+
+async function describeDiscordAttachments(
+  attachments: Iterable<DiscordAttachmentLike>,
+  group: RegisteredGroup | undefined,
+): Promise<string[]> {
+  const descriptions: string[] = [];
+  for (const att of attachments) {
+    descriptions.push(await saveDiscordAttachment(att, group));
+  }
+  return descriptions;
+}
 
 export interface DiscordChannelOpts {
   onMessage: OnInboundMessage;
@@ -85,6 +238,7 @@ export class DiscordChannel implements Channel {
       const msgId = d.id;
       const timestamp = d.timestamp || new Date().toISOString();
       let content = d.content || '';
+      const group = this.opts.registeredGroups()[chatJid];
 
       // Translate @bot mentions into trigger format
       const botId = this.client?.user?.id;
@@ -103,16 +257,10 @@ export class DiscordChannel implements Channel {
 
       // Handle attachments
       if (d.attachments?.length > 0) {
-        const descriptions = d.attachments.map((att: any) => {
-          const ct = att.content_type || '';
-          if (ct.startsWith('image/'))
-            return `[Image: ${att.filename || 'image'}]`;
-          if (ct.startsWith('video/'))
-            return `[Video: ${att.filename || 'video'}]`;
-          if (ct.startsWith('audio/'))
-            return `[Audio: ${att.filename || 'audio'}]`;
-          return `[File: ${att.filename || 'file'}]`;
-        });
+        const descriptions = await describeDiscordAttachments(
+          d.attachments,
+          group,
+        );
         content = content
           ? `${content}\n${descriptions.join('\n')}`
           : descriptions.join('\n');
@@ -151,7 +299,6 @@ export class DiscordChannel implements Channel {
       );
 
       // Only deliver for registered groups
-      const group = this.opts.registeredGroups()[chatJid];
       if (!group) {
         logger.debug(
           { chatJid, chatName: senderName },
@@ -193,6 +340,7 @@ export class DiscordChannel implements Channel {
         message.author.username;
       const sender = message.author.id;
       const msgId = message.id;
+      const group = this.opts.registeredGroups()[chatJid];
 
       // Determine chat name
       const textChannel = message.channel as TextChannel;
@@ -224,19 +372,9 @@ export class DiscordChannel implements Channel {
 
       // Handle attachments — store placeholders so the agent knows something was sent
       if (message.attachments.size > 0) {
-        const attachmentDescriptions = [...message.attachments.values()].map(
-          (att) => {
-            const contentType = att.contentType || '';
-            if (contentType.startsWith('image/')) {
-              return `[Image: ${att.name || 'image'}]`;
-            } else if (contentType.startsWith('video/')) {
-              return `[Video: ${att.name || 'video'}]`;
-            } else if (contentType.startsWith('audio/')) {
-              return `[Audio: ${att.name || 'audio'}]`;
-            } else {
-              return `[File: ${att.name || 'file'}]`;
-            }
-          },
+        const attachmentDescriptions = await describeDiscordAttachments(
+          message.attachments.values(),
+          group,
         );
         if (content) {
           content = `${content}\n${attachmentDescriptions.join('\n')}`;
@@ -274,7 +412,6 @@ export class DiscordChannel implements Channel {
       this.opts.onChatMetadata(chatJid, timestamp, chatName, 'discord', true);
 
       // Only deliver full message for registered groups
-      const group = this.opts.registeredGroups()[chatJid];
       if (!group) {
         logger.debug(
           { chatJid, chatName, bot: this.label },

--- a/src/channels/registry.test.ts
+++ b/src/channels/registry.test.ts
@@ -32,11 +32,13 @@ describe('channel registry', () => {
     expect(names).toContain('another-channel');
   });
 
-  it('later registration overwrites earlier one', () => {
+  it('rejects duplicate registrations', () => {
     const factory1 = () => null;
     const factory2 = () => null;
-    registerChannel('overwrite-test', factory1);
-    registerChannel('overwrite-test', factory2);
-    expect(getChannelFactory('overwrite-test')).toBe(factory2);
+    registerChannel('duplicate-test', factory1);
+    expect(() => registerChannel('duplicate-test', factory2)).toThrow(
+      'Channel already registered: duplicate-test',
+    );
+    expect(getChannelFactory('duplicate-test')).toBe(factory1);
   });
 });

--- a/src/channels/registry.ts
+++ b/src/channels/registry.ts
@@ -16,6 +16,9 @@ export type ChannelFactory = (opts: ChannelOpts) => Channel | null;
 const registry = new Map<string, ChannelFactory>();
 
 export function registerChannel(name: string, factory: ChannelFactory): void {
+  if (registry.has(name)) {
+    throw new Error(`Channel already registered: ${name}`);
+  }
   registry.set(name, factory);
 }
 

--- a/src/db.ts
+++ b/src/db.ts
@@ -138,7 +138,8 @@ function createSchema(database: Database.Database): void {
       `UPDATE chats SET channel = 'whatsapp', is_group = 0 WHERE jid LIKE '%@s.whatsapp.net'`,
     );
     database.exec(
-      `UPDATE chats SET channel = 'discord', is_group = 1 WHERE jid LIKE 'dc:%'`,
+      // Covers single-bot (dc:) and multi-bot (dc-name:) JID prefixes
+      `UPDATE chats SET channel = 'discord', is_group = 1 WHERE jid LIKE 'dc%:%'`,
     );
     database.exec(
       `UPDATE chats SET channel = 'telegram', is_group = 0 WHERE jid LIKE 'tg:%'`,


### PR DESCRIPTION
Follow-up hardening on top of #94 / #93 after reviewer/GPT Pro pass.

Fixes:
- Reject duplicate channel registrations instead of silently replacing factories.
- Reject/skip duplicate Discord bot routing identities case-insensitively.
- Make Discord login rejection fail startup cleanly instead of leaving startup unresolved.
- Preserve token-redaction behavior from #94.
- Harden attachment downloading from #93:
  - stream response instead of buffering the whole body before checking size;
  - enforce per-file and aggregate byte budgets while streaming;
  - allow only HTTPS Discord attachment/CDN hosts and validate redirects;
  - canonicalize group/attachment directories and reject symlink escapes;
  - write via partial files, avoid overwrites/collisions, clean up failed partials.

Verification:
- `npm ci` passed
- `npm test -- src/channels/discord.test.ts src/channels/registry.test.ts` passed
- `npm run typecheck` passed
- `npm run build` passed
- `npm test` passed
- `git diff --check` passed

No live Discord gateway run was performed.
